### PR TITLE
adding documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build_docs:
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-pip
+
+      - run: |
+          pip install --user .[rtd]
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            sphinx-build -b html docs/ docs/_build/html
+
+      - store_artifacts:
+          path: docs/_build/html/
+          destination: html
+
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,0 @@
-This folder contains useful info for plugin developers.
-
-__Content__:
-
-- [Parser architecture & design principles](architecture.md)
-- [Some guidelines for plugin developers](development.md)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "markdown-it-py"
+copyright = "2020, executable book project"
+author = "executable book project"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ["myst_nb", "sphinx_copybutton"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_title = "markdown-it-py"
+html_theme = "sphinx_book_theme"
+html_theme_options = {
+    "use_edit_page_button": True,
+    "repository_url": "https://github.com/executablebooks/markdown-it-py",
+    "repository_branch": "master",
+    "path_to_docs": "docs",
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ Before continuing, make sure you've read:
 
 1. [README](https://github.com/markdown-it/markdown-it#markdown-it)
 2. [API documentation](https://markdown-it.github.io/markdown-it/)
-3. [Architecture description](architecture.md)
+3. [Architecture description](architecture)
 
 
 ## General considerations for plugins.
@@ -34,7 +34,7 @@ Before continuing, make sure you've read:
 ## FAQ
 
 
-#### I need async rule, how to do it?
+### I need async rule, how to do it?
 
 Sorry. You can't do it directly. All complex parsers are sync by nature. But you
 can use workarounds:
@@ -48,7 +48,7 @@ Alternatively, you can render HTML, then parse it to DOM, or
 in a more convenient way.
 
 
-#### How to replace part of text token with link?
+### How to replace part of text token with link?
 
 The right sequence is to split text to several tokens and add link tokens in between.
 The result will be: `text` + `link_open` + `text` + `link_close` + `text`.
@@ -58,7 +58,7 @@ See implementations of [linkify](https://github.com/markdown-it/markdown-it/blob
 __Note.__ Don't try to replace text with HTML markup! That's not secure.
 
 
-#### Why my inline rule is not executed?
+### Why my inline rule is not executed?
 
 The inline parser skips pieces of texts to optimize speed. It stops only on [a small set of chars](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_inline/text.js), which can be tokens. We did not made this list extensible for performance reasons too.
 
@@ -66,7 +66,7 @@ If you are absolutely sure that something important is missing there - create a
 ticket and we will consider adding it as a new charcode.
 
 
-#### Why do you reject some useful things?
+### Why do you reject some useful things?
 
 We do a markdown parser. It should keep the "markdown spirit". Other things should
 be kept separate, in plugins, for example. We have no clear criteria, sorry.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+```{include} ../README.md
+```
+
+```{toctree}
+using
+architecture
+development
+security
+```

--- a/docs/using.md
+++ b/docs/using.md
@@ -1,16 +1,15 @@
 ---
-jupyter:
-  jupytext:
-    formats: ipynb,md
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.4.1
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: '0.8'
+    jupytext_version: 1.4.2
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 # Using `markdown_it`
@@ -22,21 +21,22 @@ markdown-it-py may be used as an API *via* the `markdown_it` package.
 The raw text is first parsed to syntax 'tokens',
 then these are converted to other formats using 'renderers'.
 
++++
 
 ## Quick-Start
 
 The simplest way to understand how text will be parsed is using:
 
-```python
+```{code-cell}
 from markdown_it import MarkdownIt
 ```
 
-```python
+```{code-cell}
 md = MarkdownIt()
 md.render("some *text*")
 ```
 
-```python
+```{code-cell}
 for token in md.parse("some *text*"):
     print(token)
     print()
@@ -44,27 +44,28 @@ for token in md.parse("some *text*"):
 
 ## The Parser
 
++++
 
 The `MarkdownIt` class is instantiated with parsing configuration options,
 dictating the syntax rules and additional options for the parser and renderer.
 You can define this configuration *via* a preset name (`'zero'`, `'commonmark'` or `'default'`),
 or by directly supplying a dictionary.
 
-```python
+```{code-cell}
 from markdown_it.presets import zero
 zero.make()
 ```
 
-```python
+```{code-cell}
 md = MarkdownIt("zero")
 md.options
 ```
 
-```python
+```{code-cell}
 print(md.get_active_rules())
 ```
 
-```python
+```{code-cell}
 print(md.get_all_rules())
 ```
 
@@ -73,17 +74,17 @@ You can find all the parsing rules in the source code:
 `parser_inline.py`.
 Any of the parsing rules can be enabled/disabled, and these methods are chainable:
 
-```python
+```{code-cell}
 md.render("- __*emphasise this*__")
 ```
 
-```python
+```{code-cell}
 md.enable(["list", "emphasis"]).render("- __*emphasise this*__")
 ```
 
 You can temporarily modify rules with the `reset_rules` context manager.
 
-```python
+```{code-cell}
 with md.reset_rules():
     md.disable("emphasis")
     print(md.render("__*emphasise this*__"))
@@ -92,16 +93,15 @@ md.render("__*emphasise this*__")
 
 Additionally `renderInline` runs the parser with all block syntax rules disabled.
 
-```python
+```{code-cell}
 md.renderInline("__*emphasise this*__")
 ```
-
 
 ### Plugins load
 
 Plugins load collections of additional syntax rules and render methods into the parser
 
-```python
+```{code-cell}
 from markdown_it import MarkdownIt
 from markdown_it.extensions.front_matter import front_matter_plugin
 from markdown_it.extensions.footnote import footnote_plugin
@@ -128,15 +128,14 @@ A footnote [^1]
 md.render(text)
 ```
 
-
 ## The Token Stream
 
 
-
++++
 
 Before rendering, the text is parsed to a flat token stream of block level syntax elements, with nesting defined by opening (1) and closing (-1) attributes:
 
-```python
+```{code-cell}
 md = MarkdownIt("commonmark")
 tokens = md.parse("""
 Here's some *text*
@@ -150,17 +149,17 @@ Here's some *text*
 Naturally all openings should eventually be closed,
 such that:
 
-```python
+```{code-cell}
 sum([t.nesting for t in tokens]) == 0
 ```
 
 All tokens are the same class, which can also be created outside the parser:
 
-```python
+```{code-cell}
 tokens[0]
 ```
 
-```python
+```{code-cell}
 from markdown_it.token import Token
 token = Token("paragraph_open", "p", 1, block=True, map=[1, 2])
 token == tokens[0]
@@ -168,25 +167,25 @@ token == tokens[0]
 
 The `'inline'` type token contain the inline tokens as children:
 
-```python
+```{code-cell}
 tokens[1]
 ```
 
 You can serialize a token (and its children) to a JSONable dictionary using:
 
-```python
+```{code-cell}
 print(tokens[1].as_dict())
 ```
 
 This dictionary can also be deserialized:
 
-```python
+```{code-cell}
 Token.from_dict(tokens[1].as_dict())
 ```
 
 In some use cases `nest_tokens` may be useful, to collapse the opening/closing tokens into single tokens:
 
-```python
+```{code-cell}
 from markdown_it.token import nest_tokens
 nested_tokens = nest_tokens(tokens)
 [t.type for t in nested_tokens]
@@ -196,13 +195,14 @@ This introduces a single additional class `NestedTokens`,
 containing an `opening`, `closing` and `children`, which can be a list of mixed
 `Token` and `NestedTokens`.
 
-```python
+```{code-cell}
 nested_tokens[0]
 ```
 
 ## Renderers
 
-<!-- #region -->
++++
+
 After the token stream is generated, it's passed to a [renderer](https://github.com/ExecutableBookProject/markdown-it-py/tree/master/markdown_it/renderer.py).
 It then plays all the tokens, passing each to a rule with the same name as token type.
 
@@ -213,11 +213,12 @@ with the same signature:
 def function(renderer, tokens, idx, options, env):
   return htmlResult
 ```
-<!-- #endregion -->
+
++++
 
 You can inject render methods into the instantiated render class.
 
-```python
+```{code-cell}
 md = MarkdownIt("commonmark")
 
 def render_em_open(self, tokens, idx, options, env):
@@ -230,10 +231,11 @@ md.render("*a*")
 This is a slight change to the JS version, where the renderer argument is at the end.
 Also `add_render_rule` method is specific to Python, rather than adding directly to the `md.renderer.rules`, this ensures the method is bound to the renderer.
 
++++
 
 You can also subclass a render and add the method there:
 
-```python
+```{code-cell}
 from markdown_it.renderer import RendererHTML
 
 class MyRenderer(RendererHTML):
@@ -246,7 +248,7 @@ md.render("*a*")
 
 Plugins can support multiple render types, using the `__ouput__` attribute (this is currently a Python only feature).
 
-```python
+```{code-cell}
 from markdown_it.renderer import RendererHTML
 
 class MyRenderer1(RendererHTML):
@@ -272,7 +274,7 @@ print(md.render("*a*"))
 
 Here's a more concrete example; let's replace images with vimeo links to player's iframe:
 
-```python
+```{code-cell}
 import re
 from markdown_it import MarkdownIt
 
@@ -298,7 +300,7 @@ print(md.render("![](https://www.vimeo.com/123)"))
 
 Here is another example, how to add `target="_blank"` to all links:
 
-```python
+```{code-cell}
 from markdown_it import MarkdownIt
 
 def render_blank_link(self, tokens, idx, options, env):

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,13 @@ setup(
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black==19.10b0", "pre-commit==1.17.0"],
         "testing": ["coverage", "pytest>=3.6,<4", "pytest-cov", "pytest-regressions"],
-        "rtd": ["sphinx>=2,<3", "myst-parser~=0.6.0a3", "pyyaml"],
+        "rtd": [
+            "sphinx>=2,<3",
+            "myst-parser~=0.6.0a3",
+            "pyyaml",
+            "myst-nb",
+            "sphinx-copybutton",
+        ],
         "benchmark": [
             "commonmark~=0.9.1",
             "markdown~=3.2",

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
         "testing": ["coverage", "pytest>=3.6,<4", "pytest-cov", "pytest-regressions"],
         "rtd": [
             "sphinx>=2,<3",
-            "myst-parser~=0.6.0a3",
             "pyyaml",
+            "sphinx_book_theme",
             "myst-nb",
             "sphinx-copybutton",
         ],


### PR DESCRIPTION
This adds some documentation with Sphinx - it re-purposes the pre-existing docs for this. It also re-uses the `README.md` file for the main repository as the `index.md` for the docs, though we can always change that around later if we wish.

What do you think @chrisjsewell ? If you're +1 then I'll also add this to RTD