### PR TITLE
🐛 FIX: empty lines after certain lists raises exception

### DIFF
--- a/markdown_it/rules_block/list.py
+++ b/markdown_it/rules_block/list.py
@@ -282,10 +282,11 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool):
 
         nextLine = startLine = state.line
         itemLines[1] = nextLine
-        contentStart = state.bMarks[startLine]
 
         if nextLine >= endLine:
             break
+
+        contentStart = state.bMarks[startLine]
 
         #
         # Try to check if list is terminated or continued.


### PR DESCRIPTION
This is a minimal fix for #31 

Here's a copy/paste of things discussed in the issue for reference:

When processing lists, there is a call to tokenize() that advances the state.line attribute :

    list.py 
    line 264: state.md.block.tokenize(state, startLine, endLine)

After this line is executed, state.line can be larger than endLine, leading to the IndexError when checking the state at that index.

Breaking right after this line if state.line > endLine doesn't work though, we have to update the `nextline` variable before, as well as closing the list. It's actually already in the codebase, but one line too late:

    line 280 onwards:
        token = state.push("list_item_close", "li", -1)
        token.markup = chr(markerCharCode)

        nextLine = startLine = state.line
        itemLines[1] = nextLine
        contentStart = state.bMarks[startLine]

        if nextLine >= endLine:
            break

The easy solution would be to just put the check a few lines earlier.

    line 280 onwards:
        token = state.push("list_item_close", "li", -1)
        token.markup = chr(markerCharCode)

        nextLine = startLine = state.line  # we actually need to update these before breaking

        if nextLine >= endLine:
            break

        itemLines[1] = nextLine
        contentStart = state.bMarks[startLine]

Also, I'm not sure about what itemLines does, it's not really used at all in this method.

I looked at the tokenize() method mentioned at the beginning of this post and I don't think we should modify it.