### PR TITLE
⬆️ UPGRADE: attrs -> v20

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,7 @@ For code tests, markdown-it-py uses [pytest](https://docs.pytest.org)):
 >> pytest
 ```
 
-You use [tox](https://tox.readthedocs.io), to run the tests in multiple isolated environments (see the `tox.ini` file for available test environments):
+You can also use [tox](https://tox.readthedocs.io), to run the tests in multiple isolated environments (see the `tox.ini` file for available test environments):
 
 ```shell
 >> cd markdown-it-py

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     keywords="markdown lexer parser development",
     python_requires="~=3.6",
-    install_requires=["attrs~=19.3"],
+    install_requires=["attrs>=19,<21"],
     extras_require={
         "code_style": ["pre-commit==2.6"],
         "testing": [

--- a/tox.ini
+++ b/tox.ini
@@ -6,22 +6,29 @@
 [tox]
 envlist = py{36,37,38}
 
+[testenv]
+# only recreate the environment when we use `tox -r`
+recreate = false
+
 [testenv:py{36,37,38}]
 extras = testing
-recreate = false
 commands = pytest {posargs}
 
 [testenv:py{36,37,38}-bench-core]
 extras = testing
-recreate = false
 commands = pytest benchmarking/bench_core.py {posargs}
 
 [testenv:py{36,37,38}-bench-packages]
 extras = testing,compare
-recreate = false
 commands = pytest benchmarking/bench_packages.py {posargs}
 
 [testenv:py{36,37,38}-bench-plugins]
 extras = testing
-recreate = false
 commands = pytest benchmarking/bench_plugins.py {posargs}
+
+[testenv:docs-{update,clean}]
+extras = rtd
+whitelist_externals = rm
+commands =
+    clean: rm -rf docs/_build
+    sphinx-build {posargs} -nW --keep-going -b html docs/ docs/_build/html


### PR DESCRIPTION
This is not breaking, since it only deprecates python 3.4 (see [CHANGELOG.rst]https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst))