### PR TITLE
Pre-commit improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,16 @@ repos:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
-    - id: flake8
 
   - repo: https://github.com/mgedmin/check-manifest
     rev: "0.39"
     hooks:
     - id: check-manifest
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    - id: flake8
 
   - repo: https://github.com/psf/black
     rev: 20.8b1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ exclude: >
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v3.2.0
     hooks:
     - id: check-json
     - id: check-yaml
@@ -23,7 +23,7 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.39"
+    rev: "0.42"
     hooks:
     - id: check-manifest
 


### PR DESCRIPTION
- Use upstream flake8 pre-commit hook (see https://github.com/pre-commit/pre-commit-hooks#deprecated--replaced-hooks)
- Run `pre-commit autoupdate`