### PR TITLE
🧪 Make `read_fixture_file` always read UTF-8

### DIFF
--- a/markdown_it/utils.py
+++ b/markdown_it/utils.py
@@ -13,7 +13,7 @@ class AttrDict(dict):
 
 
 def read_fixture_file(path):
-    text = Path(path).read_text()
+    text = Path(path).read_text(encoding="utf-8")
     tests = []
     section = 0
     last_pos = 0


### PR DESCRIPTION
Currently `read_fixture_file` decides file encoding based on platform. It may read different text from the same file when running on a different platform (Windows, linux, macOS etc.), and as a result, break tests on some platforms (typically windows, lol).

This PR makes the function read UTF-8 regardless of platform.
