### PR TITLE
🐛 FIX: smartquotes punctuation char comparison

### DIFF
--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -272,7 +272,7 @@ MD_ASCII_PUNCT = {
 }
 
 
-def isMdAsciiPunct(ch: str):
+def isMdAsciiPunct(ch: int):
     """Markdown ASCII punctuation characters.
 
     ::

--- a/markdown_it/rules_core/smartquotes.py
+++ b/markdown_it/rules_core/smartquotes.py
@@ -94,12 +94,8 @@ def process_inlines(tokens: List[Token], state: StateCore):
                     nextChar = charCodeAt(tokens[j].content, 0)
                     break
 
-            isLastPunctChar = isMdAsciiPunct(chr(lastChar)) or isPunctChar(
-                chr(lastChar)
-            )
-            isNextPunctChar = isMdAsciiPunct(chr(nextChar)) or isPunctChar(
-                chr(nextChar)
-            )
+            isLastPunctChar = isMdAsciiPunct(lastChar) or isPunctChar(chr(lastChar))
+            isNextPunctChar = isMdAsciiPunct(nextChar) or isPunctChar(chr(nextChar))
 
             isLastWhiteSpace = isWhiteSpace(lastChar)
             isNextWhiteSpace = isWhiteSpace(nextChar)


### PR DESCRIPTION
This bug was found by running mypy with the [`strict_equality = True`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict-equality) setting. I suggest we turn that setting on in https://github.com/executablebooks/markdown-it-py/pull/64