### PR TITLE
🐛 FIX: `MarkdownIt.render`; don't copy empty `env` arg

### DIFF
--- a/markdown_it/main.py
+++ b/markdown_it/main.py
@@ -240,7 +240,8 @@ class MarkdownIt:
         But you will not need it with high probability. See also comment
         in [[MarkdownIt.parse]].
         """
-        env = env or AttrDict()
+        if env is None:
+            env = AttrDict()
         return self.renderer.render(self.parse(src, env), self.options, env)
 
     def parseInline(self, src: str, env: Optional[AttrDict] = None) -> List[Token]:

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,6 +1,7 @@
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
 from markdown_it.rules_core import StateCore
+from markdown_it.utils import AttrDict
 
 
 def test_get_rules():
@@ -250,3 +251,16 @@ def test_noneState():
 
     # Check that we can process None str with empty env and block_tokens
     md.core.process(state)
+
+
+def test_empty_env():
+    """Test that an empty `env` is mutated, not copied and mutated."""
+    md = MarkdownIt()
+
+    env = AttrDict()
+    md.render("[foo]: /url\n[foo]", env)
+    assert "references" in env
+
+    env = AttrDict()
+    md.parse("[foo]: /url\n[foo]", env)
+    assert "references" in env


### PR DESCRIPTION
This PR makes `MarkdownIt.render` not copy an `env` if it is an empty `AttrDict`, making it possible for a caller to capture changes made to `env`. This is in line with how `MarkdownIt.parse` method, and the JS implementation works.