### PR TITLE
🐛 FIX: parsing of unicode ordinals

### DIFF
--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -92,15 +92,7 @@ def isValidEntityCode(c):
     return True
 
 
-def fromCodePoint(c):
-
-    if c > 0xFFFF:
-        c -= 0x10000
-        surrogate1 = 0xD800 + (c >> 10)
-        surrogate2 = 0xDC00 + (c & 0x3FF)
-
-        return "".join(map(chr, [surrogate1, surrogate2]))
-
+def fromCodePoint(c: int) -> str:
     return chr(c)
 
 

--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -93,12 +93,12 @@ def isValidEntityCode(c):
 
 
 def fromCodePoint(c: int) -> str:
-   """Convert ordinal to unicode.
-   
-   Note, in the original Javascript two string characters were required,
-   for codepoints larger than `0xFFFF`.
-   But Python 3 can represent any unicode codepoint in one character.
-   """
+    """Convert ordinal to unicode.
+
+    Note, in the original Javascript two string characters were required,
+    for codepoints larger than `0xFFFF`.
+    But Python 3 can represent any unicode codepoint in one character.
+    """
     return chr(c)
 
 

--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -93,6 +93,12 @@ def isValidEntityCode(c):
 
 
 def fromCodePoint(c: int) -> str:
+   """Convert ordinal to unicode.
+   
+   Note, in the original Javascript two string characters were required,
+   for codepoints larger than `0xFFFF`.
+   But Python 3 can represent any unicode codepoint in one character.
+   """
     return chr(c)
 
 

--- a/tests/test_port/fixtures/issue-fixes.md
+++ b/tests/test_port/fixtures/issue-fixes.md
@@ -29,3 +29,10 @@
 <p>Another Block Quote</p>
 </blockquote>
 .
+
+#80 UnicodeError with codepoints larger than 0xFFFF
+.
+&#x1F4AC;
+.
+<p>💬</p>
+.


### PR DESCRIPTION
Closes https://github.com/executablebooks/markdown-it-py/issues/80

This seems like a porting issue to me: Javascript needs two string characters for codepoints larger than `0xFFFF` but Python 3 can represent any unicode codepoint in one character.

This PR removes the handling that splits a large codepoint to two chars.