### PR TITLE
🐛 FIX: Exception when doc ends in heading/blockquote marker

### DIFF
--- a/markdown_it/rules_block/blockquote.py
+++ b/markdown_it/rules_block/blockquote.py
@@ -23,7 +23,6 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
 
     # check the block quote marker
     if state.srcCharCode[pos] != 0x3E:  # /* > */
-        pos += 1
         return False
     pos += 1
 
@@ -39,8 +38,13 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
         - (state.bMarks[startLine] + state.tShift[startLine])
     )
 
+    try:
+        second_char_code = state.srcCharCode[pos]
+    except IndexError:
+        second_char_code = None
+
     # skip one optional space after '>'
-    if state.srcCharCode[pos] == 0x20:  # /* space */
+    if second_char_code == 0x20:  # /* space */
         # ' >   test '
         #     ^ -- position start of line here:
         pos += 1
@@ -48,7 +52,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
         offset += 1
         adjustTab = False
         spaceAfterMarker = True
-    elif state.srcCharCode[pos] == 0x09:  # /* tab */
+    elif second_char_code == 0x09:  # /* tab */
         spaceAfterMarker = True
 
         if (state.bsCount[startLine] + offset) % 4 == 3:

--- a/markdown_it/rules_block/heading.py
+++ b/markdown_it/rules_block/heading.py
@@ -27,12 +27,18 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool):
     # count heading level
     level = 1
     pos += 1
-    ch = state.srcCharCode[pos]
+    try:
+        ch = state.srcCharCode[pos]
+    except IndexError:
+        ch = None
     # /* # */
     while ch == 0x23 and pos < maximum and level <= 6:
         level += 1
         pos += 1
-        ch = state.srcCharCode[pos]
+        try:
+            ch = state.srcCharCode[pos]
+        except IndexError:
+            ch = None
 
     if level > 6 or (pos < maximum and not isSpace(ch)):
         return False

--- a/tests/test_port/test_no_end_newline.py
+++ b/tests/test_port/test_no_end_newline.py
@@ -11,6 +11,7 @@ from markdown_it import MarkdownIt
         ("` `", "<p><code> </code></p>\n"),
         ("``````", "<pre><code></code></pre>\n"),
         ("-", "<ul>\n<li></li>\n</ul>\n"),
+        (">", "<blockquote></blockquote>\n"),
     ],
 )
 def test_no_end_newline(input, expected):

--- a/tests/test_port/test_no_end_newline.py
+++ b/tests/test_port/test_no_end_newline.py
@@ -1,0 +1,18 @@
+import pytest
+
+from markdown_it import MarkdownIt
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("#", "<h1></h1>\n"),
+        ("` `", "<p><code> </code></p>\n"),
+        ("``````", "<pre><code></code></pre>\n"),
+        ("-", "<ul>\n<li></li>\n</ul>\n"),
+    ],
+)
+def test_no_end_newline(input, expected):
+    md = MarkdownIt()
+    text = md.render(input)
+    assert text == expected

--- a/tests/test_port/test_no_end_newline.py
+++ b/tests/test_port/test_no_end_newline.py
@@ -11,7 +11,12 @@ from markdown_it import MarkdownIt
         ("` `", "<p><code> </code></p>\n"),
         ("``````", "<pre><code></code></pre>\n"),
         ("-", "<ul>\n<li></li>\n</ul>\n"),
+        ("1.", "<ol>\n<li></li>\n</ol>\n"),
         (">", "<blockquote></blockquote>\n"),
+        ("---", "<hr />\n"),
+        ("<h1></h1>", "<h1></h1>"),
+        ("p", "<p>p</p>\n"),
+        ("[reference]: /url", ""),
     ],
 )
 def test_no_end_newline(input, expected):

--- a/tests/test_port/test_no_end_newline.py
+++ b/tests/test_port/test_no_end_newline.py
@@ -7,6 +7,7 @@ from markdown_it import MarkdownIt
     "input,expected",
     [
         ("#", "<h1></h1>\n"),
+        ("###", "<h3></h3>\n"),
         ("` `", "<p><code> </code></p>\n"),
         ("``````", "<pre><code></code></pre>\n"),
         ("-", "<ul>\n<li></li>\n</ul>\n"),


### PR DESCRIPTION
Closes https://github.com/executablebooks/markdown-it-py/issues/71