### PR TITLE
👌 IMPROVE: Type annotate renderer's token stream immutable

### DIFF
--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -192,7 +192,7 @@ class RendererHTML:
 
     ###################################################
 
-    def code_inline(self, tokens, idx, options, env):
+    def code_inline(self, tokens: Sequence[Token], idx, options, env):
         token = tokens[idx]
         return (
             "<code"
@@ -202,7 +202,7 @@ class RendererHTML:
             + "</code>"
         )
 
-    def code_block(self, tokens, idx, options, env):
+    def code_block(self, tokens: Sequence[Token], idx, options, env):
         token = tokens[idx]
 
         return (
@@ -213,7 +213,7 @@ class RendererHTML:
             + "</code></pre>\n"
         )
 
-    def fence(self, tokens, idx, options, env):
+    def fence(self, tokens: Sequence[Token], idx, options, env):
         token = tokens[idx]
         info = unescapeAll(token.info).strip() if token.info else ""
         langName = ""
@@ -262,7 +262,7 @@ class RendererHTML:
             + "</code></pre>\n"
         )
 
-    def image(self, tokens, idx, options, env):
+    def image(self, tokens: Sequence[Token], idx, options, env):
         token = tokens[idx]
 
         # "alt" attr MUST be set, even if empty. Because it's mandatory and
@@ -276,19 +276,19 @@ class RendererHTML:
 
         return self.renderToken(tokens, idx, options, env)
 
-    def hardbreak(self, tokens, idx, options, *args):
+    def hardbreak(self, tokens: Sequence[Token], idx, options, *args):
         return "<br />\n" if options.xhtmlOut else "<br>\n"
 
-    def softbreak(self, tokens, idx, options, *args):
+    def softbreak(self, tokens: Sequence[Token], idx, options, *args):
         return (
             ("<br />\n" if options.xhtmlOut else "<br>\n") if options.breaks else "\n"
         )
 
-    def text(self, tokens, idx, *args):
+    def text(self, tokens: Sequence[Token], idx, *args):
         return escapeHtml(tokens[idx].content)
 
-    def html_block(self, tokens, idx, *args):
+    def html_block(self, tokens: Sequence[Token], idx, *args):
         return tokens[idx].content
 
-    def html_inline(self, tokens, idx, *args):
+    def html_inline(self, tokens: Sequence[Token], idx, *args):
         return tokens[idx].content

--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -6,7 +6,7 @@ copy of rules. Those can be rewritten with ease. Also, you can add new
 rules if you create plugin and adds new token types.
 """
 import inspect
-from typing import List
+from typing import Sequence
 
 from .common.utils import unescapeAll, escapeHtml
 from .token import Token
@@ -51,7 +51,7 @@ class RendererHTML:
             if not (k.startswith("render") or k.startswith("_"))
         }
 
-    def render(self, tokens: List[Token], options, env) -> str:
+    def render(self, tokens: Sequence[Token], options, env) -> str:
         """Takes token stream and generates HTML.
 
         :param tokens: list on block tokens to render
@@ -73,7 +73,7 @@ class RendererHTML:
 
         return result
 
-    def renderInline(self, tokens: List[Token], options, env) -> str:
+    def renderInline(self, tokens: Sequence[Token], options, env) -> str:
         """The same as ``render``, but for single token of `inline` type.
 
         :param tokens: list on block tokens to render
@@ -91,7 +91,7 @@ class RendererHTML:
         return result
 
     def renderToken(
-        self, tokens: List[Token], idx: int, options: dict, env: dict
+        self, tokens: Sequence[Token], idx: int, options: dict, env: dict
     ) -> str:
         """Default token renderer.
 
@@ -169,7 +169,7 @@ class RendererHTML:
 
         return result
 
-    def renderInlineAsText(self, tokens: List[Token], options, env) -> str:
+    def renderInlineAsText(self, tokens: Sequence[Token], options, env) -> str:
         """Special kludge for image `alt` attributes to conform CommonMark spec.
 
         Don't try to use it! Spec requires to show `alt` content with stripped markup,


### PR DESCRIPTION
The token stream should not be mutated while rendering (https://github.com/markdown-it/markdown-it/issues/260).

This PR type annotates token stream as the immutable `Sequence` to make type checkers check for possible mutation.