### PR TITLE
🧪 TEST: Enable typographer to fix skipped

### DIFF
--- a/tests/test_port/test_fixtures.py
+++ b/tests/test_port/test_fixtures.py
@@ -86,10 +86,11 @@ def test_normalize_url(line, title, input, expected):
     "line,title,input,expected", read_fixture_file(FIXTURE_PATH.joinpath("fatal.md"))
 )
 def test_fatal(line, title, input, expected):
-    if line in [1, 17, 25]:
+    if line in [1, 17]:
         # TODO fix failing url escaping tests
         pytest.skip("url normalisation")
-    md = MarkdownIt("commonmark")
+    md = MarkdownIt("commonmark").enable("replacements")
+    md.options["typographer"] = True
     text = md.render(input)
     if text.rstrip() != expected.rstrip():
         print(text)


### PR DESCRIPTION
Nothing to do with #8

`typographer` was enabled in the [js version](https://github.com/markdown-it/markdown-it/blob/master/test/markdown-it.js#L14). 

`---` will be converted to a `—`(&mdash).
