### PR TITLE
👌 IMPROVE: Make `srcCharCode` immutable

### DIFF
--- a/markdown_it/parser_block.py
+++ b/markdown_it/parser_block.py
@@ -1,6 +1,6 @@
 """Block-level tokenizer."""
 import logging
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from .ruler import Ruler
 from .token import Token
@@ -98,7 +98,7 @@ class ParserBlock:
         md,
         env,
         outTokens: List[Token],
-        ords: Optional[List[int]] = None,
+        ords: Optional[Tuple[int, ...]] = None,
     ):
         """Process input string and push block tokens into `outTokens`."""
         if not src:

--- a/markdown_it/ruler.py
+++ b/markdown_it/ruler.py
@@ -21,6 +21,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
     TYPE_CHECKING,
     Union,
 )
@@ -33,8 +34,9 @@ if TYPE_CHECKING:
 
 
 class StateBase:
+    srcCharCode: Tuple[int, ...]
+
     def __init__(self, src: str, md: "MarkdownIt", env: AttrDict):
-        self.srcCharCode: List[int] = []
         self.src = src
         self.env = env
         self.md = md
@@ -46,7 +48,9 @@ class StateBase:
     @src.setter
     def src(self, value):
         self._src = value
-        self.srcCharCode = [ord(c) for c in self.src] if self.src is not None else []
+        self.srcCharCode = (
+            tuple(ord(c) for c in self.src) if self.src is not None else ()
+        )
 
 
 # The first positional arg is always a subtype of `StateBase`. Other

--- a/markdown_it/rules_block/state_block.py
+++ b/markdown_it/rules_block/state_block.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from ..token import Token
 from ..ruler import StateBase
@@ -12,7 +12,7 @@ class StateBlock(StateBase):
         md,
         env,
         tokens: List[Token],
-        srcCharCode: Optional[List[int]] = None,
+        srcCharCode: Optional[Tuple[int, ...]] = None,
     ):
 
         if srcCharCode is not None:


### PR DESCRIPTION
`StateBase.srcCharCode` is tightly coupled with `StateBase.src` value so should not be mutated, only reassigned atomically with `StateBase.src`. This PR makes it immutable. Also prevent initializing `srcCharCode` value twice in `StateBase` init.