### PR TITLE
DRAFT: Make nest_tokens preserve unmodified tokens

### DIFF
--- a/markdown_it/token.py
+++ b/markdown_it/token.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import attr
 
@@ -117,8 +117,8 @@ class NestedTokens:
     """
 
     opening: Token = attr.ib()
-    closing: Optional[Token] = attr.ib()
-    children: List[Union[Token, "NestedTokens"]] = attr.ib(factory=list)
+    closing: Optional[Token] = attr.ib(default=None)
+    children: List["NestedTokens"] = attr.ib(factory=list)
 
     def __getattr__(self, name):
         return getattr(self.opening, name)
@@ -128,13 +128,13 @@ class NestedTokens:
         return self.opening.attrGet(name)
 
 
-def nest_tokens(tokens: List[Token]) -> List[Union[Token, NestedTokens]]:
-    """Convert the token stream to a list of tokens and nested tokens.
+def nest_tokens(tokens: List[Token]) -> List[NestedTokens]:
+    """Convert the token stream to a list of nested tokens.
 
     ``NestedTokens`` contain the open and close tokens and a list of children
     of all tokens in between (recursively nested)
     """
-    output: List[Union[Token, NestedTokens]] = []
+    output: List[NestedTokens] = []
 
     tokens = list(reversed(tokens))
     while tokens:
@@ -142,9 +142,10 @@ def nest_tokens(tokens: List[Token]) -> List[Union[Token, NestedTokens]]:
 
         if token.nesting == 0:
             token = token.copy()
-            output.append(token)
+            nested_token = NestedTokens(token)
+            output.append(nested_token)
             if token.children:
-                token.children = nest_tokens(token.children)  # type: ignore
+                nested_token.children = nest_tokens(token.children)
             continue
 
         assert token.nesting == 1, token.nesting

--- a/tests/test_api/test_token.py
+++ b/tests/test_api/test_token.py
@@ -47,9 +47,9 @@ def test_nest_tokens():
         ]
     )
     assert [t.type for t in tokens] == ["start", "open", "end"]
-    assert isinstance(tokens[0], Token)
+    assert isinstance(tokens[0], NestedTokens)
     assert isinstance(tokens[1], NestedTokens)
-    assert isinstance(tokens[2], Token)
+    assert isinstance(tokens[2], NestedTokens)
 
     nested = tokens[1]
     assert nested.opening.type == "open"


### PR DESCRIPTION
Working on mdformat I bumped into some problems where having access to the Markdown in a tree structure might simplify and prevent some hacks (doing https://github.com/executablebooks/mdformat/pull/85). I looked into `nest_tokens` and noticed it modifies and doesn't fully respect typing of `Token.children`, adding `NestedTokens` objects into a `List[Token]`. It could be useful for rendering (and perhaps other) purposes to keep the original token.

I made some tweaks that slightly change the meaning of `NestedTokens` making it more of a container of `Token`s than a replacement for them. This change makes `nest_token` respect typing of `Token.attrs`, makes rendering possibly simpler since the original tokens are kept, and probably makes it simpler to reconstruct the linear token stream.

This a draft to raise discussion. I'm not sure if I like this :smile: not sure if @chrisjsewell likes this, and some docstrings, names etc. might need to be changed before merging. I'm also not aware of how widely `NestedTokens` and `nest_tokens` are used and how destructive a change like this would be.
