### PR TITLE
👌 IMPROVE: Make `NestedTokens.closing` not optional

### DIFF
--- a/markdown_it/token.py
+++ b/markdown_it/token.py
@@ -144,6 +144,9 @@ def nest_tokens(tokens: List[Token]) -> List[Union[Token, NestedTokens]]:
             token = token.copy()
             output.append(token)
             if token.children:
+                # Ignore type checkers because `nest_tokens` doesn't respect
+                # typing of `Token.children`. We add `NestedTokens` into a
+                # `List[Token]` here.
                 token.children = nest_tokens(token.children)  # type: ignore
             continue
 

--- a/markdown_it/token.py
+++ b/markdown_it/token.py
@@ -117,7 +117,7 @@ class NestedTokens:
     """
 
     opening: Token = attr.ib()
-    closing: Optional[Token] = attr.ib()
+    closing: Token = attr.ib()
     children: List[Union[Token, "NestedTokens"]] = attr.ib(factory=list)
 
     def __getattr__(self, name):


### PR DESCRIPTION
It seems `NestedTokens` represents a `_open` token and `_close` token pair and the tokens in the stream between them. I think closing token should not be optional?