### PR TITLE
🐛 FIX: cli.parse: return 0 for non-error

### DIFF
--- a/markdown_it/cli/parse.py
+++ b/markdown_it/cli/parse.py
@@ -104,4 +104,5 @@ def print_heading() -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    exit_code = main(sys.argv[1:])
+    sys.exit(exit_code)

--- a/markdown_it/cli/parse.py
+++ b/markdown_it/cli/parse.py
@@ -21,7 +21,8 @@ def main(args: Optional[Sequence[str]] = None) -> bool:
         convert(namespace.filenames)
     else:
         interactive()
-    return True
+    RET_OK = 0
+    return RET_OK
 
 
 def convert(filenames: Iterable[str]) -> None:

--- a/markdown_it/cli/parse.py
+++ b/markdown_it/cli/parse.py
@@ -15,14 +15,13 @@ from markdown_it.main import MarkdownIt
 version_str = "markdown-it-py [version {}]".format(__version__)
 
 
-def main(args: Optional[Sequence[str]] = None) -> bool:
+def main(args: Optional[Sequence[str]] = None) -> int:
     namespace = parse_args(args)
     if namespace.filenames:
         convert(namespace.filenames)
     else:
         interactive()
-    RET_OK = 0
-    return RET_OK
+    return 0
 
 
 def convert(filenames: Iterable[str]) -> None:
@@ -39,7 +38,8 @@ def convert_file(filename: str) -> None:
             rendered = MarkdownIt().render(fin.read())
             print(rendered, end="")
     except OSError:
-        sys.exit('Cannot open file "{}".'.format(filename))
+        sys.stderr.write(f'Cannot open file "{filename}".\n')
+        sys.exit(1)
 
 
 def interactive() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ import pathlib
 import tempfile
 from unittest.mock import patch
 
+import pytest
+
 from markdown_it.cli import parse
 
 
@@ -9,7 +11,12 @@ def test_parse():
     with tempfile.TemporaryDirectory() as tempdir:
         path = pathlib.Path(tempdir).joinpath("test.md")
         path.write_text("a b c")
-        assert parse.main([str(path)])
+        assert parse.main([str(path)]) == 0
+
+
+def test_parse_fail():
+    with pytest.raises(SystemExit):
+        parse.main(["/tmp/nonexistant_path/for_cli_test.md"])
 
 
 def test_print_heading():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,8 +15,9 @@ def test_parse():
 
 
 def test_parse_fail():
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc_info:
         parse.main(["/tmp/nonexistant_path/for_cli_test.md"])
+    assert exc_info.value.code == 1
 
 
 def test_print_heading():


### PR DESCRIPTION
Based on @westurner's https://github.com/executablebooks/markdown-it-py/pull/55 with two changes:

- Fix CI
- Fix error code when running `python markdown_it/cli/parse.py`