### PR TITLE
👌 IMPROVE: MarkdownIt config and documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
     rev: 3.8.4
     hooks:
     - id: flake8
+      additional_dependencies: [flake8-bugbear==21.3.1]
 
   - repo: https://github.com/psf/black
     rev: 20.8b1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ exclude: >
       test.*\.md|
       test.*\.txt|
       test.*\.html|
+      test.*\.xml|
       .*commonmark\.json|
       benchmark/.*\.md|
       .*/spec\.md

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,7 @@ python:
       - method: pip
         path: .
         extra_requirements:
+          - linkify
           - rtd
 
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,13 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-nitpick_ignore = [("py:class", "Match"), ("py:class", "x in the interval [0, 1).")]
+nitpick_ignore = [
+    ("py:class", "Match"),
+    ("py:class", "x in the interval [0, 1)."),
+    ("py:class", "markdown_it.helpers.parse_link_destination._Result"),
+    ("py:class", "markdown_it.helpers.parse_link_title._Result"),
+    ("py:class", "MarkdownIt"),
+]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/using.md
+++ b/docs/using.md
@@ -149,7 +149,7 @@ md.render("'single quotes' (c)")
 ### Linkify
 
 The `linkify` component requires that [linkify-it-py](https://github.com/tsutsu3/linkify-it-py) be installed (e.g. *via* `pip install markdown-it-py[linkify]`).
-This allows URL links to be identified, without the need for enclosing in `<>` brackets:
+This allows URI autolinks to be identified, without the need for enclosing in `<>` brackets:
 
 ```{code-cell}
 md = MarkdownIt("commonmark", {"linkify": True})

--- a/docs/using.md
+++ b/docs/using.md
@@ -56,7 +56,7 @@ You can define this configuration *via* directly supplying a dictionary or a pre
 - `js-default`: This is the default in the JavaScript version.
   Compared to `commonmark`, it disables HTML parsing and enables the table and strikethrough components.
 - `gfm-like`: This configures the parser to approximately comply with the [GitHub Flavored Markdown specification](https://github.github.com/gfm/).
-  Compared to `commonmark`, it disables HTML parsing and enables the table, strikethrough and linkify components.
+  Compared to `commonmark`, it enables the table, strikethrough and linkify components.
   **Important**, to use this configuration you must have `linkify-it-py` installed.
 
 ```{code-cell}
@@ -279,7 +279,6 @@ node.children
 print(node[0])
 node[0].next_sibling
 ```
-
 
 ## Renderers
 

--- a/markdown_it/main.py
+++ b/markdown_it/main.py
@@ -106,9 +106,9 @@ class MarkdownIt:
         That will give better compatibility with next versions.
         """
         if isinstance(presets, str):
-            config = _PRESETS.get(presets, None)
-            if not config:
+            if presets not in _PRESETS:
                 raise KeyError(f"Wrong `markdown-it` preset '{presets}', check name")
+            config = _PRESETS[presets]
         else:
             config = presets
 

--- a/markdown_it/main.py
+++ b/markdown_it/main.py
@@ -27,36 +27,51 @@ except ModuleNotFoundError:
     linkify_it = None
 
 
-_PRESETS = AttrDict(
-    {
-        "default": presets.default.make(),
-        "zero": presets.zero.make(),
-        "commonmark": presets.commonmark.make(),
-    }
-)
+_PRESETS = {
+    "default": presets.default.make(),
+    "zero": presets.zero.make(),
+    "commonmark": presets.commonmark.make(),
+}
+_PRESETS["js-default"] = _PRESETS["default"]
+_PRESETS["gfm-like"] = presets.default.make()
+_PRESETS["gfm-like"]["options"]["linkify"] = True
 
 
 class MarkdownIt:
     def __init__(
-        self, config: Union[str, Mapping] = "commonmark", renderer_cls=RendererHTML
+        self,
+        config: Union[str, Mapping] = "commonmark",
+        options_update: Optional[Mapping] = None,
+        *,
+        renderer_cls=RendererHTML,
     ):
         """Main parser class
 
         :param config: name of configuration to load or a pre-defined dictionary
+        :param options_update: dictionary that will be merged into ``config["options"]``
         :param renderer_cls: the class to load as the renderer:
             ``self.renderer = renderer_cls(self)
         """
+        # add modules
+        self.utils = utils
+        self.helpers: Any = helpers
+
+        # initialise classes
         self.inline = ParserInline()
         self.block = ParserBlock()
         self.core = ParserCore()
         self.renderer = renderer_cls(self)
-
-        self.utils = utils
-        self.helpers: Any = helpers
-        self.options = AttrDict()
-        self.configure(config)
-
         self.linkify = linkify_it.LinkifyIt() if linkify_it else None
+
+        # set the configuration
+        if options_update and not isinstance(options_update, Mapping):
+            # catch signature change where renderer_cls was not used as a key-word
+            raise TypeError(
+                f"options_update should be a mapping: {options_update}"
+                "\n(Perhaps you intended this to be the renderer_cls?)"
+            )
+        self.options = AttrDict()
+        self.configure(config, options_update=options_update)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__module__}.{self.__class__.__name__}()"
@@ -79,7 +94,9 @@ class MarkdownIt:
         """
         self.options = options
 
-    def configure(self, presets: Union[str, Mapping]) -> "MarkdownIt":
+    def configure(
+        self, presets: Union[str, Mapping], options_update: Optional[Mapping] = None
+    ) -> "MarkdownIt":
         """Batch load of all options and component settings.
         This is an internal method, and you probably will not need it.
         But if you will - see available presets and data structure
@@ -89,21 +106,24 @@ class MarkdownIt:
         That will give better compatibility with next versions.
         """
         if isinstance(presets, str):
-            presetName = presets
-            presets = _PRESETS.get(presetName, None)
-            if not presets:
-                raise KeyError(
-                    'Wrong `markdown-it` preset "' + presetName + '", check name'
-                )
-        if not presets:
-            raise ValueError("Wrong `markdown-it` preset, can't be empty")
-        config = AttrDict(presets)
+            config = _PRESETS.get(presets, None)
+            if not config:
+                raise KeyError(f"Wrong `markdown-it` preset '{presets}', check name")
+        else:
+            config = presets
 
-        if "options" in config:
-            self.set(config.options)
+        if not config:
+            raise ValueError("Wrong `markdown-it` config, can't be empty")
+
+        options = config.get("options", {}) or {}
+        if options_update:
+            options = {**options, **options_update}
+
+        if options:
+            self.set(AttrDict(options))
 
         if "components" in config:
-            for name, component in config.components.items():
+            for name, component in config["components"].items():
                 rules = component.get("rules", None)
                 if rules:
                     self[name].ruler.enableOnly(rules)

--- a/markdown_it/main.py
+++ b/markdown_it/main.py
@@ -29,12 +29,11 @@ except ModuleNotFoundError:
 
 _PRESETS = {
     "default": presets.default.make(),
+    "js-default": presets.js_default.make(),
     "zero": presets.zero.make(),
     "commonmark": presets.commonmark.make(),
+    "gfm-like": presets.gfm_like.make(),
 }
-_PRESETS["js-default"] = _PRESETS["default"]
-_PRESETS["gfm-like"] = presets.default.make()
-_PRESETS["gfm-like"]["options"]["linkify"] = True
 
 
 class MarkdownIt:

--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -27,7 +27,7 @@
       The `MarkdownIt.__init__` signature is slightly different for updating options,
       since you must always specify the config first, e.g.
       use `MarkdownIt("commonmark", {"html": False})` instead of `MarkdownIt({"html": False})`
-    - The default configuration preset for `MarkdownIt` if "commonmark" not "default"
+    - The default configuration preset for `MarkdownIt` is "commonmark" not "default"
     - Allow custom renderer to be passed to `MarkdownIt`
     - |
       change render method signatures

--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -23,6 +23,11 @@
       In markdown_it/rules_block/reference.py,
       record line range in state.env["references"] and add state.env["duplicate_refs"]
       This is to allow renderers to report on issues regarding references
+    - |
+      The `MarkdownIt.__init__` signature is slightly different for updating options,
+      since you must always specify the config first, e.g.
+      use `MarkdownIt("commonmark", {"html": False})` instead of `MarkdownIt({"html": False})`
+    - The default configuration preset for `MarkdownIt` if "commonmark" not "default"
     - Allow custom renderer to be passed to `MarkdownIt`
     - |
       change render method signatures

--- a/markdown_it/presets/__init__.py
+++ b/markdown_it/presets/__init__.py
@@ -1,1 +1,25 @@
 from . import commonmark, default, zero  # noqa: F401
+
+js_default = default
+
+
+class gfm_like:
+    """GitHub Flavoured Markdown (GFM) like.
+
+    This adds the linkify, table and strikethrough components to CommmonMark.
+
+    Note, it lacks task-list items and raw HTML filtering,
+    to meet the the full GFM specification
+    (see https://github.github.com/gfm/#autolinks-extension-).
+    """
+
+    @staticmethod
+    def make():
+        config = commonmark.make()
+        config["components"]["core"]["rules"].append("linkify")
+        config["components"]["block"]["rules"].append("table")
+        config["components"]["inline"]["rules"].append("strikethrough")
+        config["components"]["inline"]["rules2"].append("strikethrough")
+        config["options"]["linkify"] = True
+        config["options"]["html"] = True
+        return config

--- a/markdown_it/presets/commonmark.py
+++ b/markdown_it/presets/commonmark.py
@@ -1,4 +1,11 @@
-"""Commonmark default options."""
+"""Commonmark default options.
+
+This differs to presets.default,
+primarily in that it allows HTML and does not enable components:
+
+- block: table
+- inline: strikethrough
+"""
 
 
 def make():

--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -34,7 +34,7 @@ class RendererHTML:
             def strong_close(self, tokens, idx, options, env):
                 return '</b>'
 
-        md = MarkdownIt(renderer=CustomRenderer)
+        md = MarkdownIt(renderer_cls=CustomRenderer)
 
         result = md.render(...)
 

--- a/markdown_it/tree.py
+++ b/markdown_it/tree.py
@@ -117,7 +117,7 @@ class SyntaxTreeNode:
         - `Token.type` of the opening token, with "_open" suffix stripped, if
             the node represents a nester token pair
         """
-        if not self.token and not self.nester_tokens:
+        if self.is_root:
             return "root"
         if self.token:
             return self.token.type

--- a/markdown_it/tree.py
+++ b/markdown_it/tree.py
@@ -2,6 +2,7 @@
 
 This module is not part of upstream JavaScript markdown-it.
 """
+import textwrap
 from typing import NamedTuple, Sequence, Tuple, Dict, List, Optional, Any
 
 from .token import Token
@@ -44,6 +45,12 @@ class SyntaxTreeNode:
         # children (i.e. inline or img)
         self.children: List["SyntaxTreeNode"] = []
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.type})"
+
+    def __getitem__(self, item: int) -> "SyntaxTreeNode":
+        return self.children[item]
+
     @classmethod
     def from_tokens(cls, tokens: Sequence[Token]) -> "SyntaxTreeNode":
         """Instantiate a `SyntaxTreeNode` from a token stream.
@@ -75,6 +82,11 @@ class SyntaxTreeNode:
         tokens: List[Token] = []
         recursive_collect_tokens(self, tokens)
         return tokens
+
+    @property
+    def is_root(self) -> bool:
+        """Is the node a special root node?"""
+        return not (self.token or self.nester_tokens)
 
     @property
     def is_nested(self) -> bool:
@@ -182,6 +194,23 @@ class SyntaxTreeNode:
                 )
             )
             child._set_children_from_tokens(nested_tokens[1:-1])
+
+    def pretty(
+        self, *, indent: int = 2, show_text: bool = False, _current: int = 0
+    ) -> str:
+        """Create an XML style string of the tree."""
+        prefix = " " * _current
+        text = prefix + f"<{self.type}"
+        if not self.is_root and self.attrs:
+            text += " " + " ".join(f"{k}={v!r}" for k, v in self.attrs.items())
+        text += ">"
+        if show_text and not self.is_root and self.type == "text" and self.content:
+            text += "\n" + textwrap.indent(self.content, prefix + " " * indent)
+        for child in self.children:
+            text += "\n" + child.pretty(
+                indent=indent, show_text=show_text, _current=_current + indent
+            )
+        return text
 
     # NOTE:
     # The values of the properties defined below directly map to properties

--- a/markdown_it/tree.py
+++ b/markdown_it/tree.py
@@ -46,7 +46,7 @@ class SyntaxTreeNode:
         self.children: List["SyntaxTreeNode"] = []
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.type})"
+        return f"{type(self).__name__}({self.type})"
 
     def __getitem__(self, item: int) -> "SyntaxTreeNode":
         return self.children[item]

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -85,6 +85,13 @@ def test_load_presets():
     }
 
 
+def test_override_options():
+    md = MarkdownIt("zero")
+    assert md.options["maxNesting"] == 20
+    md = MarkdownIt("zero", {"maxNesting": 99})
+    assert md.options["maxNesting"] == 99
+
+
 def test_enable():
     md = MarkdownIt("zero").enable("heading")
     assert md.get_active_rules() == {

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -37,6 +37,7 @@ def test_type():
     assert tree.type == "root"
     # "_open" suffix must be stripped from nested token type
     assert tree.children[0].type == "heading"
+    assert tree[0].type == "heading"
     # For unnested tokens, node type must remain same as token type
     assert tree.children[0].children[0].type == "inline"
 
@@ -54,3 +55,20 @@ def test_sibling_traverse():
     assert another_text_node.next_sibling is None
     assert another_text_node.previous_sibling.previous_sibling == text_node
     assert text_node.previous_sibling is None
+
+
+def test_pretty(file_regression):
+    md = MarkdownIt("commonmark")
+    tokens = md.parse(
+        """
+# Header
+
+Here's some text and an image ![title](image.png)
+
+1. a **list**
+
+> a *quote*
+    """
+    )
+    node = SyntaxTreeNode.from_tokens(tokens)
+    file_regression.check(node.pretty(indent=2, show_text=True), extension=".xml")

--- a/tests/test_tree/test_pretty.xml
+++ b/tests/test_tree/test_pretty.xml
@@ -1,0 +1,30 @@
+<root>
+  <heading>
+    <inline>
+      <text>
+        Header
+  <paragraph>
+    <inline>
+      <text>
+        Here's some text and an image 
+      <image src='image.png' alt=''>
+        <text>
+          title
+  <ordered_list>
+    <list_item>
+      <paragraph>
+        <inline>
+          <text>
+            a 
+          <strong>
+            <text>
+              list
+          <text>
+  <blockquote>
+    <paragraph>
+      <inline>
+        <text>
+          a 
+        <em>
+          <text>
+            quote

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ extras = testing
 commands = pytest benchmarking/bench_plugins.py {posargs}
 
 [testenv:docs-{update,clean}]
-extras = rtd
+extras = linkify,rtd
 whitelist_externals = rm
 setenv =
     update: SKIP_APIDOC = true


### PR DESCRIPTION
Add additional configuration presets,
allow for options tp be overriden in the `MarkdownIt` initialisation,
Add convenience methods to `SyntaxTreeNode`