### PR TITLE
🐛 FIX: Linkify link nesting levels

### DIFF
--- a/markdown_it/rules_core/linkify.py
+++ b/markdown_it/rules_core/linkify.py
@@ -114,16 +114,18 @@ def linkify(state: StateCore) -> None:
                     token = Token("link_open", "a", 1)
                     token.attrs = [["href", fullUrl]]
                     token.level = level
+                    level += 1
                     token.markup = "linkify"
                     token.info = "auto"
                     nodes.append(token)
 
                     token = Token("text", "", 0)
                     token.content = urlText
-                    token.level = level + 1
+                    token.level = level
                     nodes.append(token)
 
                     token = Token("link_close", "a", -1)
+                    level -= 1
                     token.level = level
                     token.markup = "linkify"
                     token.info = "auto"

--- a/markdown_it/rules_core/linkify.py
+++ b/markdown_it/rules_core/linkify.py
@@ -113,18 +113,18 @@ def linkify(state: StateCore) -> None:
 
                     token = Token("link_open", "a", 1)
                     token.attrs = [["href", fullUrl]]
-                    token.level = level + 1
+                    token.level = level
                     token.markup = "linkify"
                     token.info = "auto"
                     nodes.append(token)
 
                     token = Token("text", "", 0)
                     token.content = urlText
-                    token.level = level
+                    token.level = level + 1
                     nodes.append(token)
 
                     token = Token("link_close", "a", -1)
-                    token.level = level - 1
+                    token.level = level
                     token.markup = "linkify"
                     token.info = "auto"
                     nodes.append(token)

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -1,0 +1,19 @@
+from markdown_it import MarkdownIt
+
+
+def test_token_levels():
+    mdit = MarkdownIt(options_update={"linkify": True}).enable("linkify")
+    tokens = mdit.parse("www.python.org")
+    inline = tokens[1]
+    assert inline.type == "inline"
+    link_open = inline.children[0]
+    assert link_open.type == "link_open"
+    link_text = inline.children[1]
+    assert link_text.type == "text"
+    link_close = inline.children[2]
+    assert link_close.type == "link_close"
+
+    # Assert that linkify tokens have correct nesting levels
+    assert link_open.level == 0
+    assert link_text.level == 1
+    assert link_close.level == 0


### PR DESCRIPTION
It seems to me like linkify link tokens have incorrect nesting levels. This PR fixes that.

~~This seems like a bug inherited from upstream. I'll make a quick PR there as well.~~ EDIT: On closer inspection this seems like a porting issue, so not making an upstream PR.