### PR TITLE
✨ NEW: Add SyntaxTreeNode.walk

### DIFF
--- a/markdown_it/tree.py
+++ b/markdown_it/tree.py
@@ -4,6 +4,7 @@ This module is not part of upstream JavaScript markdown-it.
 """
 import textwrap
 from typing import (
+    Generator,
     NamedTuple,
     Sequence,
     Tuple,
@@ -247,6 +248,19 @@ class SyntaxTreeNode:
                 indent=indent, show_text=show_text, _current=_current + indent
             )
         return text
+
+    def walk(
+        self: _NodeType, *, include_self: bool = True
+    ) -> Generator[_NodeType, None, None]:
+        """Recursively yield all descendant nodes in the tree starting at self.
+
+        The order mimics the order of the underlying linear token
+        stream (i.e. depth first).
+        """
+        if include_self:
+            yield self
+        for child in self.children:
+            yield from child.walk(include_self=True)
 
     # NOTE:
     # The values of the properties defined below directly map to properties

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -72,3 +72,22 @@ Here's some text and an image ![title](image.png)
     )
     node = SyntaxTreeNode(tokens)
     file_regression.check(node.pretty(indent=2, show_text=True), extension=".xml")
+
+
+def test_walk():
+    tokens = MarkdownIt().parse(EXAMPLE_MARKDOWN)
+    tree = SyntaxTreeNode(tokens)
+    expected_node_types = (
+        "root",
+        "heading",
+        "inline",
+        "text",
+        "paragraph",
+        "inline",
+        "text",
+        "strong",
+        "text",
+        "text",
+    )
+    for node, expected_type in zip(tree.walk(), expected_node_types):
+        assert node.type == expected_type


### PR DESCRIPTION
Add a method for SyntaxTreeNode traversal.

Would be useful e.g. here https://github.com/executablebooks/mdformat-tables/pull/7/files