### PR TITLE
📚 DOCS: Fix deprecated import

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ with and without plugins and features:
 
 ```python
 from markdown_it import MarkdownIt
-from markdown_it.extensions.front_matter import front_matter_plugin
-from markdown_it.extensions.footnote import footnote_plugin
+from mdit_py_plugins.front_matter import front_matter_plugin
+from mdit_py_plugins.footnote import footnote_plugin
 
 md = (
     MarkdownIt()
@@ -68,6 +68,11 @@ A footnote [^1]
 """)
 tokens = md.parse(text)
 html_text = md.render(text)
+
+## To export the html to a file, uncomment the lines below:
+#text_file = open("output.html", "w")
+#text_file.write(html_text)
+#text_file.close()
 ```
 
 ### Command-line Usage

--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ tokens = md.parse(text)
 html_text = md.render(text)
 
 ## To export the html to a file, uncomment the lines below:
-#text_file = open("output.html", "w")
-#text_file.write(html_text)
-#text_file.close()
+# from pathlib import Path
+# Path("output.html").write_text(html_text)
 ```
 
 ### Command-line Usage


### PR DESCRIPTION
Hello,

I was playing with this package and noticed that there are a couple of warning messages with the current important commands. 

Also one other suggestion is to add some code for people to export the html to a file if they happen to not be working in an interactive python session. Happy to remove this if it doesn't make sense for others.