### PR TITLE
‼️ BREAKING: Replace use of `AttrDict` for env/options

### DIFF
--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -12,6 +12,10 @@
       this is generally the main difference between the codes,
       because in python you can't do e.g. `for {i=1;i<x;i++} {}`
     - |
+      `env` is a common Python dictionary, and so does not have attribute access to keys,
+      as with JavaScript dictionaries.
+      `options` have attribute access only to core markdownit configuration options
+    - |
       `Token.attrs` is a dictionary, instead of a list of lists.
       Upstream the list format is only used to guarantee order: https://github.com/markdown-it/markdown-it/issues/142,
       but in Python 3.7+ order of dictionaries is guaranteed.

--- a/markdown_it/presets/commonmark.py
+++ b/markdown_it/presets/commonmark.py
@@ -34,7 +34,7 @@ def make():
             # or '' if the source string is not changed and should be escaped externally.
             # If result starts with <pre... internal wrapper is skipped.
             #
-            # function (/*str, lang*/) { return ''; }
+            # function (/*str, lang, attrs*/) { return ''; }
             #
             "highlight": None,
         },

--- a/markdown_it/presets/default.py
+++ b/markdown_it/presets/default.py
@@ -26,7 +26,7 @@ def make():
             # or '' if the source string is not changed and should be escaped externaly.
             # If result starts with <pre... internal wrapper is skipped.
             #
-            # function (/*str, lang*/) { return ''; }
+            # function (/*str, lang, attrs*/) { return ''; }
             #
             "highlight": None,
         },

--- a/markdown_it/presets/zero.py
+++ b/markdown_it/presets/zero.py
@@ -28,7 +28,7 @@ def make():
             # Highlighter function. Should return escaped HTML,
             # or '' if the source string is not changed and should be escaped externaly.
             # If result starts with <pre... internal wrapper is skipped.
-            # function (/*str, lang*/) { return ''; }
+            # function (/*str, lang, attrs*/) { return ''; }
             "highlight": None,
         },
         "components": {

--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -6,10 +6,11 @@ copy of rules. Those can be rewritten with ease. Also, you can add new
 rules if you create plugin and adds new token types.
 """
 import inspect
-from typing import Optional, Sequence
+from typing import MutableMapping, Optional, Sequence
 
 from .common.utils import unescapeAll, escapeHtml
 from .token import Token
+from .utils import OptionsDict
 
 
 class RendererHTML:
@@ -51,7 +52,9 @@ class RendererHTML:
             if not (k.startswith("render") or k.startswith("_"))
         }
 
-    def render(self, tokens: Sequence[Token], options, env) -> str:
+    def render(
+        self, tokens: Sequence[Token], options: OptionsDict, env: MutableMapping
+    ) -> str:
         """Takes token stream and generates HTML.
 
         :param tokens: list on block tokens to render
@@ -73,7 +76,9 @@ class RendererHTML:
 
         return result
 
-    def renderInline(self, tokens: Sequence[Token], options, env) -> str:
+    def renderInline(
+        self, tokens: Sequence[Token], options: OptionsDict, env: MutableMapping
+    ) -> str:
         """The same as ``render``, but for single token of `inline` type.
 
         :param tokens: list on block tokens to render
@@ -91,7 +96,11 @@ class RendererHTML:
         return result
 
     def renderToken(
-        self, tokens: Sequence[Token], idx: int, options: dict, env: dict
+        self,
+        tokens: Sequence[Token],
+        idx: int,
+        options: OptionsDict,
+        env: MutableMapping,
     ) -> str:
         """Default token renderer.
 
@@ -161,7 +170,10 @@ class RendererHTML:
         return result
 
     def renderInlineAsText(
-        self, tokens: Optional[Sequence[Token]], options, env
+        self,
+        tokens: Optional[Sequence[Token]],
+        options: OptionsDict,
+        env: MutableMapping,
     ) -> str:
         """Special kludge for image `alt` attributes to conform CommonMark spec.
 
@@ -195,7 +207,13 @@ class RendererHTML:
             + "</code>"
         )
 
-    def code_block(self, tokens: Sequence[Token], idx: int, options, env) -> str:
+    def code_block(
+        self,
+        tokens: Sequence[Token],
+        idx: int,
+        options: OptionsDict,
+        env: MutableMapping,
+    ) -> str:
         token = tokens[idx]
 
         return (
@@ -206,7 +224,13 @@ class RendererHTML:
             + "</code></pre>\n"
         )
 
-    def fence(self, tokens: Sequence[Token], idx: int, options, env) -> str:
+    def fence(
+        self,
+        tokens: Sequence[Token],
+        idx: int,
+        options: OptionsDict,
+        env: MutableMapping,
+    ) -> str:
         token = tokens[idx]
         info = unescapeAll(token.info).strip() if token.info else ""
         langName = ""
@@ -252,7 +276,13 @@ class RendererHTML:
             + "</code></pre>\n"
         )
 
-    def image(self, tokens: Sequence[Token], idx: int, options, env) -> str:
+    def image(
+        self,
+        tokens: Sequence[Token],
+        idx: int,
+        options: OptionsDict,
+        env: MutableMapping,
+    ) -> str:
         token = tokens[idx]
 
         # "alt" attr MUST be set, even if empty. Because it's mandatory and
@@ -268,10 +298,14 @@ class RendererHTML:
 
         return self.renderToken(tokens, idx, options, env)
 
-    def hardbreak(self, tokens: Sequence[Token], idx: int, options, *args) -> str:
+    def hardbreak(
+        self, tokens: Sequence[Token], idx: int, options: OptionsDict, *args
+    ) -> str:
         return "<br />\n" if options.xhtmlOut else "<br>\n"
 
-    def softbreak(self, tokens: Sequence[Token], idx: int, options, *args) -> str:
+    def softbreak(
+        self, tokens: Sequence[Token], idx: int, options: OptionsDict, *args
+    ) -> str:
         return (
             ("<br />\n" if options.xhtmlOut else "<br>\n") if options.breaks else "\n"
         )

--- a/markdown_it/ruler.py
+++ b/markdown_it/ruler.py
@@ -20,14 +20,13 @@ from typing import (
     Dict,
     Iterable,
     List,
+    MutableMapping,
     Optional,
     Tuple,
     TYPE_CHECKING,
     Union,
 )
 import attr
-
-from markdown_it.utils import AttrDict
 
 if TYPE_CHECKING:
     from markdown_it import MarkdownIt
@@ -36,7 +35,7 @@ if TYPE_CHECKING:
 class StateBase:
     srcCharCode: Tuple[int, ...]
 
-    def __init__(self, src: str, md: "MarkdownIt", env: AttrDict):
+    def __init__(self, src: str, md: "MarkdownIt", env: MutableMapping):
         self.src = src
         self.env = env
         self.md = md

--- a/markdown_it/rules_block/reference.py
+++ b/markdown_it/rules_block/reference.py
@@ -1,7 +1,6 @@
 import logging
 
 from ..common.utils import isSpace, normalizeReference, charCodeAt
-from ..utils import AttrDict
 from .state_block import StateBlock
 
 
@@ -189,19 +188,19 @@ def reference(state: StateBlock, startLine, _endLine, silent):
     state.line = startLine + lines + 1
 
     if label not in state.env["references"]:
-        state.env["references"][label] = AttrDict(
-            {"title": title, "href": href, "map": [startLine, state.line]}
-        )
+        state.env["references"][label] = {
+            "title": title,
+            "href": href,
+            "map": [startLine, state.line],
+        }
     else:
         state.env.setdefault("duplicate_refs", []).append(
-            AttrDict(
-                {
-                    "title": title,
-                    "href": href,
-                    "label": label,
-                    "map": [startLine, state.line],
-                }
-            )
+            {
+                "title": title,
+                "href": href,
+                "label": label,
+                "map": [startLine, state.line],
+            }
         )
 
     state.parentType = oldParentType

--- a/markdown_it/rules_core/state_core.py
+++ b/markdown_it/rules_core/state_core.py
@@ -1,6 +1,5 @@
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, MutableMapping, Optional, TYPE_CHECKING
 
-from ..utils import AttrDict
 from ..token import Token
 from ..ruler import StateBase
 
@@ -13,7 +12,7 @@ class StateCore(StateBase):
         self,
         src: str,
         md: "MarkdownIt",
-        env: AttrDict,
+        env: MutableMapping,
         tokens: Optional[List[Token]] = None,
     ):
         self.src = src

--- a/markdown_it/rules_inline/image.py
+++ b/markdown_it/rules_inline/image.py
@@ -117,13 +117,13 @@ def image(state: StateInline, silent: bool):
 
         label = normalizeReference(label)
 
-        ref = state.env.references.get(label, None)
+        ref = state.env["references"].get(label, None)
         if not ref:
             state.pos = oldPos
             return False
 
-        href = ref.href
-        title = ref.title
+        href = ref["href"]
+        title = ref["title"]
 
     #
     # We found the end of the link, and know for a fact it's a valid link

--- a/markdown_it/rules_inline/link.py
+++ b/markdown_it/rules_inline/link.py
@@ -113,13 +113,15 @@ def link(state: StateInline, silent: bool):
 
         label = normalizeReference(label)
 
-        ref = state.env.references[label] if label in state.env.references else None
+        ref = (
+            state.env["references"][label] if label in state.env["references"] else None
+        )
         if not ref:
             state.pos = oldPos
             return False
 
-        href = ref.href
-        title = ref.title
+        href = ref["href"]
+        title = ref["title"]
 
     #
     # We found the end of the link, and know for a fact it's a valid link

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -1,9 +1,8 @@
 from collections import namedtuple
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, MutableMapping, Optional, TYPE_CHECKING
 
 import attr
 
-from ..utils import AttrDict
 from ..token import Token
 from ..ruler import StateBase
 from ..common.utils import isWhiteSpace, isPunctChar, isMdAsciiPunct
@@ -48,7 +47,7 @@ Scanned = namedtuple("Scanned", ["can_open", "can_close", "length"])
 
 class StateInline(StateBase):
     def __init__(
-        self, src: str, md: "MarkdownIt", env: AttrDict, outTokens: List[Token]
+        self, src: str, md: "MarkdownIt", env: MutableMapping, outTokens: List[Token]
     ):
         self.src = src
         self.env = env

--- a/markdown_it/utils.py
+++ b/markdown_it/utils.py
@@ -1,5 +1,90 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+
+
+class OptionsDict(dict):
+    """A dictionary, with attribute access to core markdownit configuration options."""
+
+    @property
+    def maxNesting(self) -> int:
+        """Internal protection, recursion limit."""
+        return self["maxNesting"]
+
+    @maxNesting.setter
+    def maxNesting(self, value: int):
+        self["maxNesting"] = value
+
+    @property
+    def html(self) -> bool:
+        """Enable HTML tags in source."""
+        return self["html"]
+
+    @html.setter
+    def html(self, value: bool):
+        self["html"] = value
+
+    @property
+    def linkify(self) -> bool:
+        """Enable autoconversion of URL-like texts to links."""
+        return self["linkify"]
+
+    @linkify.setter
+    def linkify(self, value: bool):
+        self["linkify"] = value
+
+    @property
+    def typographer(self) -> bool:
+        """Enable smartquotes and replacements."""
+        return self["typographer"]
+
+    @typographer.setter
+    def typographer(self, value: bool):
+        self["typographer"] = value
+
+    @property
+    def quotes(self) -> str:
+        """Quote characters."""
+        return self["quotes"]
+
+    @quotes.setter
+    def quotes(self, value: str):
+        self["quotes"] = value
+
+    @property
+    def xhtmlOut(self) -> bool:
+        """Use '/' to close single tags (<br />)."""
+        return self["xhtmlOut"]
+
+    @xhtmlOut.setter
+    def xhtmlOut(self, value: bool):
+        self["xhtmlOut"] = value
+
+    @property
+    def breaks(self) -> bool:
+        """Convert newlines in paragraphs into <br>."""
+        return self["breaks"]
+
+    @breaks.setter
+    def breaks(self, value: bool):
+        self["breaks"] = value
+
+    @property
+    def langPrefix(self) -> str:
+        """CSS language prefix for fenced blocks."""
+        return self["langPrefix"]
+
+    @langPrefix.setter
+    def langPrefix(self, value: str):
+        self["langPrefix"] = value
+
+    @property
+    def highlight(self) -> Optional[Callable[[str, str, str], str]]:
+        """Highlighter function: (content, langName, langAttrs) -> escaped HTML."""
+        return self["highlight"]
+
+    @highlight.setter
+    def highlight(self, value: Optional[Callable[[str, str, str], str]]):
+        self["highlight"] = value
 
 
 if TYPE_CHECKING:

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,7 +1,6 @@
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
 from markdown_it.rules_core import StateCore
-from markdown_it.utils import AttrDict
 
 
 def test_get_rules():
@@ -271,11 +270,11 @@ def test_empty_env():
     """Test that an empty `env` is mutated, not copied and mutated."""
     md = MarkdownIt()
 
-    env = AttrDict()
+    env = {}
     md.render("[foo]: /url\n[foo]", env)
     assert "references" in env
 
-    env = AttrDict()
+    env = {}
     md.parse("[foo]: /url\n[foo]", env)
     assert "references" in env
 

--- a/tests/test_port/test_references.py
+++ b/tests/test_port/test_references.py
@@ -1,12 +1,11 @@
 from markdown_it import MarkdownIt
-from markdown_it.utils import AttrDict
 
 
 def test_ref_definitions():
 
     md = MarkdownIt()
     src = "[a]: abc\n\n[b]: xyz\n\n[b]: ijk"
-    env = AttrDict()
+    env = {}
     tokens = md.parse(src, env)
     assert tokens == []
     assert env == {
@@ -21,14 +20,12 @@ def test_ref_definitions():
 def test_use_existing_env(data_regression):
     md = MarkdownIt()
     src = "[a]\n\n[c]: ijk"
-    env = AttrDict(
-        {
-            "references": {
-                "A": {"title": "", "href": "abc", "map": [0, 1]},
-                "B": {"title": "", "href": "xyz", "map": [2, 3]},
-            }
+    env = {
+        "references": {
+            "A": {"title": "", "href": "abc", "map": [0, 1]},
+            "B": {"title": "", "href": "xyz", "map": [2, 3]},
         }
-    )
+    }
     tokens = md.parse(src, env)
     data_regression.check([token.as_dict() for token in tokens])
     assert env == {


### PR DESCRIPTION
For `env` any Python mutable mapping is now allowed,
and so attribute access to keys is not allowed.
For `MarkdownIt.options` it is now set as an `OptionsDict`,
which is a dictionary sub-class, with attribute access
only for core markdownit configuration keys.