### PR TITLE
🔧 MAINTAIN: Update development packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,3 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies: [attrs]
-
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.16.0
-    hooks:
-    - id: setup-cfg-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ exclude: >
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
     - id: check-json
     - id: check-yaml
@@ -24,9 +24,18 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.44"
+    rev: "0.46"
     hooks:
     - id: check-manifest
+      args: [--no-build-isolation]
+      additional_dependencies: [setuptools>=46.4.0]
+
+  # this is not used for now,
+  # since it converts markdown-it-py to markdown_it_py and removes comments
+  # - repo: https://github.com/asottile/setup-cfg-fmt
+  #   rev: v1.17.0
+  #   hooks:
+  #   - id: setup-cfg-fmt
 
   - repo: https://github.com/psf/black
     rev: 20.8b1
@@ -34,13 +43,13 @@ repos:
     - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
     - id: flake8
       additional_dependencies: [flake8-bugbear==21.3.1]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.812
     hooks:
     - id: mypy
       additional_dependencies: [attrs]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ nitpick_ignore = [
     ("py:class", "markdown_it.helpers.parse_link_destination._Result"),
     ("py:class", "markdown_it.helpers.parse_link_title._Result"),
     ("py:class", "MarkdownIt"),
+    ("py:class", "_NodeType"),
 ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ linkify =
 plugins =
     mdit-py-plugins
 rtd =
-    myst-nb~=0.11.1
+    myst-nb==0.13.0a1
     pyyaml
     sphinx>=2,<4
     sphinx-copybutton

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = markdown_it_py
+name = markdown-it-py
 version = attr: markdown_it.__version__
 description = Python port of markdown-it. Markdown parsing, done right!
 long_description = file: README.md


### PR DESCRIPTION
The name of the package is already set up to use `markdown-it-py` in numerous places, but setup_cfg_fmt is hard-coded to convert these dashes to underscores https://github.com/asottile/setup-cfg-fmt/blob/de922db829605a067c7a407eb42620c3cb4466a0/setup_cfg_fmt.py#L365 🤷 