### PR TITLE
🐛 FIX: Newline not rendered in image alt attribute

### DIFF
--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -1,7 +1,7 @@
 - package: markdown-it/markdown-it
-  version: 12.0.5
-  commit: 3740146fc9c92ea15fdc6a358137ec7b68f05f4b
-  date: Apr 14, 2021
+  version: 12.0.6
+  commit: df4607f1d4d4be7fdc32e71c04109aea8cc373fa
+  date: Apr 16, 2021
   notes:
     - Rename variables that use python built-in names, e.g.
       - `max` -> `maximum`

--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -192,6 +192,8 @@ class RendererHTML:
             elif token.type == "image":
                 assert token.children is not None
                 result += self.renderInlineAsText(token.children, options, env)
+            elif token.type == "softbreak":
+                result += "\n"
 
         return result
 

--- a/tests/test_port/fixtures/commonmark_extras.md
+++ b/tests/test_port/fixtures/commonmark_extras.md
@@ -629,3 +629,12 @@ baz</p>
 </blockquote>
 </blockquote>
 .
+
+Newline in image description
+.
+There is a newline in this image ![here
+it is](https://github.com/executablebooks/)
+.
+<p>There is a newline in this image <img src="https://github.com/executablebooks/" alt="here
+it is" /></p>
+.


### PR DESCRIPTION
This is a sibling of the upstream PR https://github.com/markdown-it/markdown-it/pull/775