### PR TITLE
🐛 FIX: Raise HTML blocks priority to resolve conflict with headings

### DIFF
--- a/markdown_it/parser_block.py
+++ b/markdown_it/parser_block.py
@@ -24,9 +24,9 @@ _rules: List[Tuple] = [
     ("hr", rules_block.hr, ["paragraph", "reference", "blockquote", "list"]),
     ("list", rules_block.list_block, ["paragraph", "reference", "blockquote"]),
     ("reference", rules_block.reference),
+    ("html_block", rules_block.html_block, ["paragraph", "reference", "blockquote"]),
     ("heading", rules_block.heading, ["paragraph", "reference", "blockquote"]),
     ("lheading", rules_block.lheading),
-    ("html_block", rules_block.html_block, ["paragraph", "reference", "blockquote"]),
     ("paragraph", rules_block.paragraph),
 ]
 

--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -1,7 +1,7 @@
 - package: markdown-it/markdown-it
-  version: 12.0.4
-  commit: cd5296f1e7de2b978526178631859c18bb9d9928
-  date: Mar 27, 2021
+  version: 12.0.5
+  commit: 3740146fc9c92ea15fdc6a358137ec7b68f05f4b
+  date: Apr 14, 2021
   notes:
     - Rename variables that use python built-in names, e.g.
       - `max` -> `maximum`

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -23,9 +23,9 @@ def test_get_rules():
             "hr",
             "list",
             "reference",
+            "html_block",
             "heading",
             "lheading",
-            "html_block",
             "paragraph",
         ],
         "inline": [
@@ -63,9 +63,9 @@ def test_load_presets():
             "hr",
             "list",
             "reference",
+            "html_block",
             "heading",
             "lheading",
-            "html_block",
             "paragraph",
         ],
         "inline": [

--- a/tests/test_port/fixtures/commonmark_extras.md
+++ b/tests/test_port/fixtures/commonmark_extras.md
@@ -629,3 +629,21 @@ baz</p>
 </blockquote>
 </blockquote>
 .
+
+Issue #772. Header rule should not interfere with html tags.
+.
+<!--
+==
+-->
+
+<pre>
+==
+</pre>
+.
+<!--
+==
+-->
+<pre>
+==
+</pre>
+.


### PR DESCRIPTION
Sibling PR to upstream commit https://github.com/markdown-it/markdown-it/commit/309c03a9e856ad5f39ea5e7c066198a93b9331fb