### PR TITLE
📚 DOCS: Move plugin documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ nitpick_ignore = [
     ("py:class", "markdown_it.helpers.parse_link_title._Result"),
     ("py:class", "MarkdownIt"),
     ("py:class", "_NodeType"),
+    ("py:class", "typing_extensions.Protocol"),
 ]
 
 
@@ -78,6 +79,7 @@ panels_add_boostrap_css = False
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.7", None),
+    "mdit-py-plugins": ("https://mdit-py-plugins.readthedocs.io/en/latest/", None),
 }
 
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,17 +2,41 @@
 
 # Plugin extensions
 
-The following plugins are embedded within the core package (enabled when using the `"default"` preset configuration):
+The following plugins are embedded within the core package:
 
 - [tables](https://help.github.com/articles/organizing-information-with-tables/) (GFM)
 - [strikethrough](https://help.github.com/articles/basic-writing-and-formatting-syntax/#styling-text) (GFM)
 
-Other plugins are then available *via* the [`mdit_py_plugins`](https://github.com/executablebooks/mdit-py-plugins).
+These can be enabled individually:
 
-```{important}
-``markdown_it.extensions`` is now deprecated and plugins have been moved to
-[`mdit_py_plugins`](https://github.com/executablebooks/mdit-py-plugins)
+```python
+from markdown_it import MarkdownIt
+md = MarkdownIt("commonmark").enable('table')
 ```
+
+or as part of a configuration:
+
+```python
+from markdown_it import MarkdownIt
+md = MarkdownIt("gfm-like")
+```
+
+```{seealso}
+See [](using.md)
+```
+
+Many other plugins are then available *via* the [`mdit-py-plugins` package](mdit-py-plugins:index), including:
+
+- Front-matter
+- Footnotes
+- Definition lists
+- Task lists
+- Heading anchors
+- LaTeX math
+- Containers
+- Word count
+
+Or you can write them yourself!
 
 They can be chained and loaded *via*:
 
@@ -22,44 +46,3 @@ from mdit_py_plugins import plugin1, plugin2
 md = MarkdownIt().use(plugin1, keyword=value).use(plugin2, keyword=value)
 html_string = md.render("some *Markdown*")
 ```
-
-```{eval-rst}
-.. autofunction:: mdit_py_plugins.anchors.anchors_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.footnote.footnote_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.front_matter.front_matter_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.container.container_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.deflist.deflist_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.texmath.texmath_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.dollarmath.dollarmath_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.amsmath.amsmath_plugin
-    :noindex:
-
-.. autofunction:: mdit_py_plugins.tasklists.tasklists_plugin
-    :noindex:
-```
-
-`myst_blocks` and `myst_role` plugins are also available, for utilisation by the [MyST renderer](https://myst-parser.readthedocs.io/en/latest/using/syntax.html)
-
-There are also many other plugins which could easily be ported (and hopefully will be):
-
-- [subscript](https://github.com/markdown-it/markdown-it-sub)
-- [superscript](https://github.com/markdown-it/markdown-it-sup)
-- [abbreviation](https://github.com/markdown-it/markdown-it-abbr)
-- [emoji](https://github.com/markdown-it/markdown-it-emoji)
-- [insert](https://github.com/markdown-it/markdown-it-ins)
-- [mark](https://github.com/markdown-it/markdown-it-mark)
-- ... and [others](https://www.npmjs.org/browse/keyword/markdown-it-plugin)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -25,7 +25,7 @@ md = MarkdownIt("gfm-like")
 See [](using.md)
 ```
 
-Many other plugins are then available *via* the [`mdit-py-plugins` package](mdit-py-plugins:index), including:
+Many other plugins are then available *via* the `mdit-py-plugins` package, including:
 
 - Front-matter
 - Footnotes
@@ -35,6 +35,8 @@ Many other plugins are then available *via* the [`mdit-py-plugins` package](mdit
 - LaTeX math
 - Containers
 - Word count
+
+For full information see: <https://mdit-py-plugins.readthedocs.io>
 
 Or you can write them yourself!
 


### PR DESCRIPTION
Moved to https://mdit-py-plugins.readthedocs.io