### PR TITLE
🐛 FIX: Always suffix indented code block with newline

### DIFF
--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -1,7 +1,7 @@
 - package: markdown-it/markdown-it
   version: 12.1.0
-  commit: 13cdeb95abccc78a5ce17acf9f6e8cf5b9ce713b
-  date: Jul 1, 2021
+  commit: e5986bb7cca20ac95dc81e4741c08949bf01bb77
+  date: Jul 15, 2021
   notes:
     - Rename variables that use python built-in names, e.g.
       - `max` -> `maximum`

--- a/markdown_it/rules_block/code.py
+++ b/markdown_it/rules_block/code.py
@@ -29,7 +29,7 @@ def code(state: StateBlock, startLine: int, endLine: int, silent: bool = False):
     state.line = last
 
     token = state.push("code_block", "code", 0)
-    token.content = state.getLines(startLine, last, 4 + state.blkIndent, True)
+    token.content = state.getLines(startLine, last, 4 + state.blkIndent, False) + "\n"
     token.map = [startLine, state.line]
 
     return True

--- a/tests/test_port/test_no_end_newline.py
+++ b/tests/test_port/test_no_end_newline.py
@@ -17,6 +17,7 @@ from markdown_it import MarkdownIt
         ("<h1></h1>", "<h1></h1>"),
         ("p", "<p>p</p>\n"),
         ("[reference]: /url", ""),
+        ("    indented code block", "<pre><code>indented code block\n</code></pre>\n"),
     ],
 )
 def test_no_end_newline(input, expected):


### PR DESCRIPTION
I'll propose this change upstream and add a link here soon. Probably don't want to merge before accepted upstream.

EDIT: Here's the upstream PR https://github.com/markdown-it/markdown-it/pull/799