### PR TITLE
Explicity reexport MarkdownIt

### DIFF
--- a/markdown_it/__init__.py
+++ b/markdown_it/__init__.py
@@ -1,4 +1,5 @@
-from .main import MarkdownIt  # noqa: F401
+from .main import MarkdownIt
 
 
+__all__ = ["MarkdownIt"]
 __version__ = "1.1.0"


### PR DESCRIPTION
Explicitly export MarkdownIt.

Adds MarkdownIt to `__all__`.

This:

1. Allows markdown_it to pass strict mypy type checking, specifically `--no-implicit-reexport`
2. Removes the need for ignoring F401, as flake8 detects the use in `__all__`
