### PR TITLE
♻️ REFACTOR: Remove `AttrDict`

### DIFF
--- a/markdown_it/common/entities.py
+++ b/markdown_it/common/entities.py
@@ -1,9 +1,4 @@
 """HTML5 entities map: { name -> characters }."""
 import html.entities
 
-from markdown_it.utils import AttrDict
-
-
-DATA = {name.rstrip(";"): chars for name, chars in html.entities.html5.items()}
-
-entities = AttrDict(DATA)
+entities = {name.rstrip(";"): chars for name, chars in html.entities.html5.items()}

--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -22,16 +22,6 @@ def charCodeAt(src: str, pos: int) -> Any:
         return None
 
 
-# function _class(obj) { return Object.prototype.toString.call(obj); }
-
-
-def isString(obj: object) -> bool:
-    return isinstance(obj, str)
-
-
-has = hasattr
-
-
 # Merge objects
 #
 def assign(obj):

--- a/markdown_it/rules_block/list.py
+++ b/markdown_it/rules_block/list.py
@@ -200,9 +200,9 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool):
         while pos < maximum:
             ch = state.srcCharCode[pos]
 
-            if ch == 0x09:
+            if ch == 0x09:  # \t
                 offset += 4 - (offset + state.bsCount[nextLine]) % 4
-            elif ch == 0x20:
+            elif ch == 0x20:  # \s
                 offset += 1
             else:
                 break

--- a/markdown_it/rules_inline/entity.py
+++ b/markdown_it/rules_inline/entity.py
@@ -2,7 +2,7 @@
 import re
 
 from ..common.entities import entities
-from ..common.utils import has, isValidEntityCode, fromCodePoint
+from ..common.utils import isValidEntityCode, fromCodePoint
 from .state_inline import StateInline
 
 DIGITAL_RE = re.compile(r"^&#((?:x[a-f0-9]{1,6}|[0-9]{1,7}));", re.IGNORECASE)
@@ -42,7 +42,7 @@ def entity(state: StateInline, silent: bool):
         else:
             match = NAMED_RE.search(state.src[pos:])
             if match:
-                if has(entities, match.group(1)):
+                if match.group(1) in entities:
                     if not silent:
                         state.pending += entities[match.group(1)]
                     state.pos += len(match.group(0))

--- a/markdown_it/utils.py
+++ b/markdown_it/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 
 class OptionsDict(dict):
@@ -85,21 +85,6 @@ class OptionsDict(dict):
     @highlight.setter
     def highlight(self, value: Optional[Callable[[str, str, str], str]]):
         self["highlight"] = value
-
-
-if TYPE_CHECKING:
-    AttrDict = Any
-else:
-
-    class AttrDict(dict):
-        def __init__(self, *args, **kwargs):
-            super(AttrDict, self).__init__(*args, **kwargs)
-            self.__dict__ = self
-
-            # recursively apply to all nested dictionaries
-            for key, item in list(self.items()):
-                if isinstance(item, dict):
-                    self[key] = AttrDict(item)
 
 
 def read_fixture_file(path: Union[str, Path]) -> List[list]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,8 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    mdurl
     attrs>=19,<22
+    mdurl~=0.1
     typing_extensions>=3.7.4;python_version<'3.8'
 python_requires = ~=3.6
 include_package_data = True


### PR DESCRIPTION
This is no longer used is core or mdit-py-plugins,
instead standard dictionaries are used.