### PR TITLE
🔧 MAINTAIN: Remove upper pin from `attrs`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    attrs>=19,<22
+    attrs>=19
     mdurl~=0.1
     typing_extensions>=3.7.4;python_version<'3.8'
 python_requires = ~=3.6


### PR DESCRIPTION
`attrs` follows CalVer not SemVer, so upper pinning the "major" version shouldn't help much. It's year 2022 now so the next `attrs` version will be incompatible (With the upper pin that is. The code will be compatible because we see no `DeprecationWarning`s.)

See also: https://www.attrs.org/en/stable/changelog.html#changelog

> Versions follow CalVer with a strict backwards-compatibility policy.

> Put simply, you shouldn’t ever be afraid to upgrade attrs if you’re only using its public APIs. Whenever there is a need to break compatibility, it is announced here in the changelog, and raises a DeprecationWarning for a year (if possible) before it’s finally really broken.