### PR TITLE
🐛 FIX: Crash when file ends with empty blockquote line

### DIFF
--- a/markdown_it/rules_block/blockquote.py
+++ b/markdown_it/rules_block/blockquote.py
@@ -154,8 +154,13 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
             # set offset past spaces and ">"
             initial = offset = state.sCount[nextLine] + 1
 
+            try:
+                next_char: Optional[int] = state.srcCharCode[pos]
+            except IndexError:
+                next_char = None
+
             # skip one optional space after '>'
-            if state.srcCharCode[pos] == 0x20:  # /* space */
+            if next_char == 0x20:  # /* space */
                 # ' >   test '
                 #     ^ -- position start of line here:
                 pos += 1
@@ -163,7 +168,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
                 offset += 1
                 adjustTab = False
                 spaceAfterMarker = True
-            elif state.srcCharCode[pos] == 0x09:  # /* tab */
+            elif next_char == 0x09:  # /* tab */
                 spaceAfterMarker = True
 
                 if (state.bsCount[nextLine] + offset) % 4 == 3:

--- a/tests/test_port/test_no_end_newline.py
+++ b/tests/test_port/test_no_end_newline.py
@@ -18,6 +18,7 @@ from markdown_it import MarkdownIt
         ("p", "<p>p</p>\n"),
         ("[reference]: /url", ""),
         ("    indented code block", "<pre><code>indented code block\n</code></pre>\n"),
+        ("> test\n>", "<blockquote>\n<p>test</p>\n</blockquote>\n"),
     ],
 )
 def test_no_end_newline(input, expected):


### PR DESCRIPTION
Closes https://github.com/executablebooks/markdown-it-py/issues/185