### PR TITLE
Implement JS-esque `StateBase.srcCharCodeAt`

### DIFF
--- a/markdown_it/helpers/parse_link_label.py
+++ b/markdown_it/helpers/parse_link_label.py
@@ -18,7 +18,7 @@ def parseLinkLabel(state: StateInline, start: int, disableNested: bool = False) 
     level = 1
 
     while state.pos < state.posMax:
-        marker = state.srcCharCode[state.pos]
+        marker = state.srcCharCodeAt(state.pos)
         if marker == 0x5D:  # /* ] */)
             level -= 1
             if level == 0:

--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -23,8 +23,9 @@
       to manipulate `Token.attrs`, which have an identical signature to those upstream.
     - Use python version of `charCodeAt`
     - |
-      Reduce use of charCodeAt() by storing char codes in a srcCharCodes attribute for state
-      objects and sharing those whenever possible
+      Reduce use of charCodeAt() by storing char codes in an `_ords` attribute
+      (accessible via `srcCharCodeAt` method) for state objects and sharing
+      those whenever possible.
       This provides a significant performance boost
     - |
       In markdown_it/rules_block/reference.py,

--- a/markdown_it/ruler.py
+++ b/markdown_it/ruler.py
@@ -26,6 +26,8 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+import warnings
+
 import attr
 
 if TYPE_CHECKING:
@@ -33,7 +35,7 @@ if TYPE_CHECKING:
 
 
 class StateBase:
-    srcCharCode: Tuple[int, ...]
+    _srcCharCode: Tuple[int, ...]
 
     def __init__(self, src: str, md: "MarkdownIt", env: MutableMapping):
         self.src = src
@@ -47,7 +49,22 @@ class StateBase:
     @src.setter
     def src(self, value: str) -> None:
         self._src = value
-        self.srcCharCode = tuple(ord(c) for c in self.src)
+        self._srcCharCode = tuple(ord(c) for c in self.src)
+
+    @property
+    def srcCharCode(self) -> Tuple[int, ...]:
+        warnings.warn(
+            "`StateBase.srcCharCode` is deprecated. Use `StateBase.srcCharCodeAt`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._srcCharCode
+
+    def srcCharCodeAt(self, idx: int) -> Optional[int]:
+        try:
+            return self._srcCharCode[idx]
+        except IndexError:
+            return None
 
 
 # The first positional arg is always a subtype of `StateBase`. Other

--- a/markdown_it/ruler.py
+++ b/markdown_it/ruler.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 
 class StateBase:
-    _srcCharCode: Tuple[int, ...]
+    _ords: Tuple[int, ...]
 
     def __init__(self, src: str, md: "MarkdownIt", env: MutableMapping):
         self.src = src
@@ -49,7 +49,7 @@ class StateBase:
     @src.setter
     def src(self, value: str) -> None:
         self._src = value
-        self._srcCharCode = tuple(ord(c) for c in self.src)
+        self._ords = tuple(ord(c) for c in self.src)
 
     @property
     def srcCharCode(self) -> Tuple[int, ...]:
@@ -58,11 +58,11 @@ class StateBase:
             DeprecationWarning,
             stacklevel=2,
         )
-        return self._srcCharCode
+        return self._ords
 
     def srcCharCodeAt(self, idx: int) -> Optional[int]:
         try:
-            return self._srcCharCode[idx]
+            return self._ords[idx]
         except IndexError:
             return None
 

--- a/markdown_it/rules_block/blockquote.py
+++ b/markdown_it/rules_block/blockquote.py
@@ -1,6 +1,5 @@
 # Block quotes
 import logging
-from typing import Optional
 
 from .state_block import StateBlock
 from ..common.utils import isSpace
@@ -35,13 +34,8 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
     # set offset past spaces and ">"
     initial = offset = state.sCount[startLine] + 1
 
-    try:
-        second_char_code: Optional[int] = state.srcCharCodeAt(pos)
-    except IndexError:
-        second_char_code = None
-
     # skip one optional space after '>'
-    if second_char_code == 0x20:  # /* space */
+    if state.srcCharCodeAt(pos) == 0x20:  # /* space */
         # ' >   test '
         #     ^ -- position start of line here:
         pos += 1
@@ -49,7 +43,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
         offset += 1
         adjustTab = False
         spaceAfterMarker = True
-    elif second_char_code == 0x09:  # /* tab */
+    elif state.srcCharCodeAt(pos) == 0x09:  # /* tab */
         spaceAfterMarker = True
 
         if (state.bsCount[startLine] + offset) % 4 == 3:
@@ -154,13 +148,8 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
             # set offset past spaces and ">"
             initial = offset = state.sCount[nextLine] + 1
 
-            try:
-                next_char: Optional[int] = state.srcCharCodeAt(pos)
-            except IndexError:
-                next_char = None
-
             # skip one optional space after '>'
-            if next_char == 0x20:  # /* space */
+            if state.srcCharCodeAt(pos) == 0x20:  # /* space */
                 # ' >   test '
                 #     ^ -- position start of line here:
                 pos += 1
@@ -168,7 +157,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
                 offset += 1
                 adjustTab = False
                 spaceAfterMarker = True
-            elif next_char == 0x09:  # /* tab */
+            elif state.srcCharCodeAt(pos) == 0x09:  # /* tab */
                 spaceAfterMarker = True
 
                 if (state.bsCount[nextLine] + offset) % 4 == 3:

--- a/markdown_it/rules_block/blockquote.py
+++ b/markdown_it/rules_block/blockquote.py
@@ -23,7 +23,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
         return False
 
     # check the block quote marker
-    if state.srcCharCode[pos] != 0x3E:  # /* > */
+    if state.srcCharCodeAt(pos) != 0x3E:  # /* > */
         return False
     pos += 1
 
@@ -36,7 +36,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
     initial = offset = state.sCount[startLine] + 1
 
     try:
-        second_char_code: Optional[int] = state.srcCharCode[pos]
+        second_char_code: Optional[int] = state.srcCharCodeAt(pos)
     except IndexError:
         second_char_code = None
 
@@ -72,7 +72,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
     state.bMarks[startLine] = pos
 
     while pos < max:
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
 
         if isSpace(ch):
             if ch == 0x09:  # / tab /
@@ -146,7 +146,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
             # Case 1: line is not inside the blockquote, and this line is empty.
             break
 
-        evaluatesTrue = state.srcCharCode[pos] == 0x3E and not isOutdented  # /* > */
+        evaluatesTrue = state.srcCharCodeAt(pos) == 0x3E and not isOutdented  # /* > */
         pos += 1
         if evaluatesTrue:
             # This line is inside the blockquote.
@@ -155,7 +155,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
             initial = offset = state.sCount[nextLine] + 1
 
             try:
-                next_char: Optional[int] = state.srcCharCode[pos]
+                next_char: Optional[int] = state.srcCharCodeAt(pos)
             except IndexError:
                 next_char = None
 
@@ -191,7 +191,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool):
             state.bMarks[nextLine] = pos
 
             while pos < max:
-                ch = state.srcCharCode[pos]
+                ch = state.srcCharCodeAt(pos)
 
                 if isSpace(ch):
                     if ch == 0x09:

--- a/markdown_it/rules_block/fence.py
+++ b/markdown_it/rules_block/fence.py
@@ -21,7 +21,7 @@ def fence(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if pos + 3 > maximum:
         return False
 
-    marker = state.srcCharCode[pos]
+    marker = state.srcCharCodeAt(pos)
 
     # /* ~ */  /* ` */
     if marker != 0x7E and marker != 0x60:
@@ -67,7 +67,7 @@ def fence(state: StateBlock, startLine: int, endLine: int, silent: bool):
             #  test
             break
 
-        if state.srcCharCode[pos] != marker:
+        if state.srcCharCodeAt(pos) != marker:
             continue
 
         if state.sCount[nextLine] - state.blkIndent >= 4:

--- a/markdown_it/rules_block/heading.py
+++ b/markdown_it/rules_block/heading.py
@@ -1,6 +1,5 @@
 """ Atex heading (#, ##, ...) """
 import logging
-from typing import Optional
 
 from .state_block import StateBlock
 from ..common.utils import isSpace
@@ -19,7 +18,7 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if state.sCount[startLine] - state.blkIndent >= 4:
         return False
 
-    ch: Optional[int] = state.srcCharCodeAt(pos)
+    ch = state.srcCharCodeAt(pos)
 
     # /* # */
     if ch != 0x23 or pos >= maximum:
@@ -28,18 +27,12 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool):
     # count heading level
     level = 1
     pos += 1
-    try:
-        ch = state.srcCharCodeAt(pos)
-    except IndexError:
-        ch = None
+    ch = state.srcCharCodeAt(pos)
     # /* # */
     while ch == 0x23 and pos < maximum and level <= 6:
         level += 1
         pos += 1
-        try:
-            ch = state.srcCharCodeAt(pos)
-        except IndexError:
-            ch = None
+        ch = state.srcCharCodeAt(pos)
 
     if level > 6 or (pos < maximum and not isSpace(ch)):
         return False

--- a/markdown_it/rules_block/heading.py
+++ b/markdown_it/rules_block/heading.py
@@ -19,7 +19,7 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if state.sCount[startLine] - state.blkIndent >= 4:
         return False
 
-    ch: Optional[int] = state.srcCharCode[pos]
+    ch: Optional[int] = state.srcCharCodeAt(pos)
 
     # /* # */
     if ch != 0x23 or pos >= maximum:
@@ -29,7 +29,7 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool):
     level = 1
     pos += 1
     try:
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
     except IndexError:
         ch = None
     # /* # */
@@ -37,7 +37,7 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool):
         level += 1
         pos += 1
         try:
-            ch = state.srcCharCode[pos]
+            ch = state.srcCharCodeAt(pos)
         except IndexError:
             ch = None
 
@@ -51,7 +51,7 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool):
 
     maximum = state.skipSpacesBack(maximum, pos)
     tmp = state.skipCharsBack(maximum, 0x23, pos)  # #
-    if tmp > pos and isSpace(state.srcCharCode[tmp - 1]):
+    if tmp > pos and isSpace(state.srcCharCodeAt(tmp - 1)):
         maximum = tmp
 
     state.line = startLine + 1

--- a/markdown_it/rules_block/hr.py
+++ b/markdown_it/rules_block/hr.py
@@ -22,7 +22,7 @@ def hr(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if state.sCount[startLine] - state.blkIndent >= 4:
         return False
 
-    marker = state.srcCharCode[pos]
+    marker = state.srcCharCodeAt(pos)
     pos += 1
 
     # Check hr marker: /* * */ /* - */ /* _ */
@@ -33,7 +33,7 @@ def hr(state: StateBlock, startLine: int, endLine: int, silent: bool):
 
     cnt = 1
     while pos < maximum:
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
         pos += 1
         if ch != marker and not isSpace(ch):
             return False

--- a/markdown_it/rules_block/html_block.py
+++ b/markdown_it/rules_block/html_block.py
@@ -44,7 +44,7 @@ def html_block(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if not state.md.options.get("html", None):
         return False
 
-    if state.srcCharCode[pos] != 0x3C:  # /* < */
+    if state.srcCharCodeAt(pos) != 0x3C:  # /* < */
         return False
 
     lineText = state.src[pos:maximum]

--- a/markdown_it/rules_block/lheading.py
+++ b/markdown_it/rules_block/lheading.py
@@ -37,7 +37,7 @@ def lheading(state: StateBlock, startLine: int, endLine: int, silent: bool):
             maximum = state.eMarks[nextLine]
 
             if pos < maximum:
-                marker = state.srcCharCode[pos]
+                marker = state.srcCharCodeAt(pos)
 
                 # /* - */  /* = */
                 if marker == 0x2D or marker == 0x3D:
@@ -74,6 +74,7 @@ def lheading(state: StateBlock, startLine: int, endLine: int, silent: bool):
     state.line = nextLine + 1
 
     token = state.push("heading_open", "h" + str(level), 1)
+    assert marker is not None
     token.markup = chr(marker)
     token.map = [startLine, state.line]
 

--- a/markdown_it/rules_block/list.py
+++ b/markdown_it/rules_block/list.py
@@ -14,14 +14,14 @@ def skipBulletListMarker(state: StateBlock, startLine: int):
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
 
-    marker = state.srcCharCode[pos]
+    marker = state.srcCharCodeAt(pos)
     pos += 1
     # Check bullet /* * */ /* - */ /* + */
     if marker != 0x2A and marker != 0x2D and marker != 0x2B:
         return -1
 
     if pos < maximum:
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
 
         if not isSpace(ch):
             # " -test " - is not a list item
@@ -42,7 +42,8 @@ def skipOrderedListMarker(state: StateBlock, startLine: int):
     if pos + 1 >= maximum:
         return -1
 
-    ch = state.srcCharCode[pos]
+    ch = state.srcCharCodeAt(pos)
+    assert ch is not None
     pos += 1
 
     # /* 0 */  /* 9 */
@@ -54,7 +55,8 @@ def skipOrderedListMarker(state: StateBlock, startLine: int):
         if pos >= maximum:
             return -1
 
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
+        assert ch is not None
         pos += 1
 
         # /* 0 */  /* 9 */
@@ -74,7 +76,7 @@ def skipOrderedListMarker(state: StateBlock, startLine: int):
         return -1
 
     if pos < maximum:
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
 
         if not isSpace(ch):
             # " 1.test " - is not a list item
@@ -156,7 +158,8 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool):
             return False
 
     # We should terminate list on style change. Remember first one to compare.
-    markerCharCode = state.srcCharCode[posAfterMarker - 1]
+    markerCharCode = state.srcCharCodeAt(posAfterMarker - 1)
+    assert markerCharCode is not None
 
     # For validation mode we can terminate immediately
     if silent:
@@ -198,7 +201,7 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool):
         )
 
         while pos < maximum:
-            ch = state.srcCharCode[pos]
+            ch = state.srcCharCodeAt(pos)
 
             if ch == 0x09:  # \t
                 offset += 4 - (offset + state.bsCount[nextLine]) % 4
@@ -318,7 +321,7 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool):
             if posAfterMarker < 0:
                 break
 
-        if markerCharCode != state.srcCharCode[posAfterMarker - 1]:
+        if markerCharCode != state.srcCharCodeAt(posAfterMarker - 1):
             break
 
     # Finalize list

--- a/markdown_it/rules_block/reference.py
+++ b/markdown_it/rules_block/reference.py
@@ -22,17 +22,17 @@ def reference(state: StateBlock, startLine, _endLine, silent):
     if state.sCount[startLine] - state.blkIndent >= 4:
         return False
 
-    if state.srcCharCode[pos] != 0x5B:  # /* [ */
+    if state.srcCharCodeAt(pos) != 0x5B:  # /* [ */
         return False
 
     # Simple check to quickly interrupt scan on [link](url) at the start of line.
     # Can be useful on practice: https:#github.com/markdown-it/markdown-it/issues/54
     while pos < maximum:
         # /* ] */  /* \ */  /* : */
-        if state.srcCharCode[pos] == 0x5D and state.srcCharCode[pos - 1] != 0x5C:
+        if state.srcCharCodeAt(pos) == 0x5D and state.srcCharCodeAt(pos - 1) != 0x5C:
             if pos + 1 == maximum:
                 return False
-            if state.srcCharCode[pos + 1] != 0x3A:
+            if state.srcCharCodeAt(pos + 1) != 0x3A:
                 return False
             break
         pos += 1

--- a/markdown_it/rules_block/state_block.py
+++ b/markdown_it/rules_block/state_block.py
@@ -20,7 +20,7 @@ class StateBlock(StateBase):
 
         if srcCharCode is not None:
             self._src = src
-            self.srcCharCode = srcCharCode
+            self._srcCharCode = srcCharCode
         else:
             self.src = src
 
@@ -78,7 +78,7 @@ class StateBlock(StateBase):
         start = pos = indent = offset = 0
         length = len(self.src)
 
-        for pos, character in enumerate(self.srcCharCode):
+        for pos, character in enumerate(self._srcCharCode):
             if not indent_found:
                 if isSpace(character):
                     indent += 1

--- a/markdown_it/rules_block/state_block.py
+++ b/markdown_it/rules_block/state_block.py
@@ -20,7 +20,7 @@ class StateBlock(StateBase):
 
         if srcCharCode is not None:
             self._src = src
-            self._srcCharCode = srcCharCode
+            self._ords = srcCharCode
         else:
             self.src = src
 
@@ -78,7 +78,7 @@ class StateBlock(StateBase):
         start = pos = indent = offset = 0
         length = len(self.src)
 
-        for pos, character in enumerate(self._srcCharCode):
+        for pos, character in enumerate(self._ords):
             if not indent_found:
                 if isSpace(character):
                     indent += 1

--- a/markdown_it/rules_block/state_block.py
+++ b/markdown_it/rules_block/state_block.py
@@ -153,7 +153,7 @@ class StateBlock(StateBase):
     def skipSpaces(self, pos: int) -> int:
         """Skip spaces from given position."""
         while pos < len(self.src):
-            if not isSpace(self.srcCharCode[pos]):
+            if not isSpace(self.srcCharCodeAt(pos)):
                 break
             pos += 1
         return pos
@@ -164,14 +164,14 @@ class StateBlock(StateBase):
             return pos
         while pos > minimum:
             pos -= 1
-            if not isSpace(self.srcCharCode[pos]):
+            if not isSpace(self.srcCharCodeAt(pos)):
                 return pos + 1
         return pos
 
     def skipChars(self, pos: int, code: int) -> int:
         """Skip char codes from given position."""
         while pos < len(self.src):
-            if self.srcCharCode[pos] != code:
+            if self.srcCharCodeAt(pos) != code:
                 break
             pos += 1
         return pos
@@ -182,7 +182,7 @@ class StateBlock(StateBase):
             return pos
         while pos > minimum:
             pos -= 1
-            if code != self.srcCharCode[pos]:
+            if code != self.srcCharCodeAt(pos):
                 return pos + 1
         return pos
 
@@ -204,7 +204,7 @@ class StateBlock(StateBase):
                 last = self.eMarks[line]
 
             while (first < last) and (lineIndent < indent):
-                ch = self.srcCharCode[first]
+                ch = self.srcCharCodeAt(first)
                 if isSpace(ch):
                     if ch == 0x09:
                         lineIndent += 4 - (lineIndent + self.bsCount[line]) % 4

--- a/markdown_it/rules_block/table.py
+++ b/markdown_it/rules_block/table.py
@@ -71,14 +71,14 @@ def table(state: StateBlock, startLine: int, endLine: int, silent: bool):
     pos = state.bMarks[nextLine] + state.tShift[nextLine]
     if pos >= state.eMarks[nextLine]:
         return False
-    first_ch = state.srcCharCode[pos]
+    first_ch = state.srcCharCodeAt(pos)
     pos += 1
     if first_ch not in {0x7C, 0x2D, 0x3A}:  # not in {"|", "-", ":"}
         return False
 
     if pos >= state.eMarks[nextLine]:
         return False
-    second_ch = state.srcCharCode[pos]
+    second_ch = state.srcCharCodeAt(pos)
     pos += 1
     # not in {"|", "-", ":"} and not space
     if second_ch not in {0x7C, 0x2D, 0x3A} and not isSpace(second_ch):
@@ -90,7 +90,7 @@ def table(state: StateBlock, startLine: int, endLine: int, silent: bool):
         return False
 
     while pos < state.eMarks[nextLine]:
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
 
         # /* | */  /* - */ /* : */
         if ch not in {0x7C, 0x2D, 0x3A} and not isSpace(ch):

--- a/markdown_it/rules_core/block.py
+++ b/markdown_it/rules_core/block.py
@@ -11,6 +11,4 @@ def block(state: StateCore) -> None:
         token.children = []
         state.tokens.append(token)
     else:
-        state.md.block.parse(
-            state.src, state.md, state.env, state.tokens, state.srcCharCode
-        )
+        state.md.block.parse(state.src, state.md, state.env, state.tokens, state._ords)

--- a/markdown_it/rules_inline/autolink.py
+++ b/markdown_it/rules_inline/autolink.py
@@ -12,7 +12,7 @@ def autolink(state: StateInline, silent: bool) -> bool:
 
     pos = state.pos
 
-    if state.srcCharCode[pos] != 0x3C:  # /* < */
+    if state.srcCharCodeAt(pos) != 0x3C:  # /* < */
         return False
 
     start = state.pos
@@ -23,7 +23,7 @@ def autolink(state: StateInline, silent: bool) -> bool:
         if pos >= maximum:
             return False
 
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
 
         if ch == 0x3C:  # /* < */
             return False

--- a/markdown_it/rules_inline/backticks.py
+++ b/markdown_it/rules_inline/backticks.py
@@ -9,7 +9,7 @@ regex = re.compile("^ (.+) $")
 def backtick(state: StateInline, silent: bool) -> bool:
 
     pos = state.pos
-    ch = state.srcCharCode[pos]
+    ch = state.srcCharCodeAt(pos)
 
     # /* ` */
     if ch != 0x60:
@@ -20,7 +20,7 @@ def backtick(state: StateInline, silent: bool) -> bool:
     maximum = state.posMax
 
     # scan marker length
-    while pos < maximum and (state.srcCharCode[pos] == 0x60):  # /* ` */
+    while pos < maximum and (state.srcCharCodeAt(pos) == 0x60):  # /* ` */
         pos += 1
 
     marker = state.src[start:pos]
@@ -43,7 +43,7 @@ def backtick(state: StateInline, silent: bool) -> bool:
         matchEnd = matchStart + 1
 
         # scan marker length
-        while matchEnd < maximum and (state.srcCharCode[matchEnd] == 0x60):  # /* ` */
+        while matchEnd < maximum and (state.srcCharCodeAt(matchEnd) == 0x60):  # /* ` */
             matchEnd += 1
 
         closerLength = matchEnd - matchStart

--- a/markdown_it/rules_inline/emphasis.py
+++ b/markdown_it/rules_inline/emphasis.py
@@ -7,7 +7,7 @@ from .state_inline import StateInline, Delimiter
 def tokenize(state: StateInline, silent: bool):
     """Insert each marker as a separate text token, and add it to delimiter list"""
     start = state.pos
-    marker = state.srcCharCode[start]
+    marker = state.srcCharCodeAt(start)
 
     if silent:
         return False

--- a/markdown_it/rules_inline/entity.py
+++ b/markdown_it/rules_inline/entity.py
@@ -14,11 +14,11 @@ def entity(state: StateInline, silent: bool):
     pos = state.pos
     maximum = state.posMax
 
-    if state.srcCharCode[pos] != 0x26:  # /* & */
+    if state.srcCharCodeAt(pos) != 0x26:  # /* & */
         return False
 
     if (pos + 1) < maximum:
-        ch = state.srcCharCode[pos + 1]
+        ch = state.srcCharCodeAt(pos + 1)
 
         if ch == 0x23:  # /* # */
             match = DIGITAL_RE.search(state.src[pos:])

--- a/markdown_it/rules_inline/escape.py
+++ b/markdown_it/rules_inline/escape.py
@@ -15,13 +15,14 @@ def escape(state: StateInline, silent: bool):
     maximum = state.posMax
 
     # /* \ */
-    if state.srcCharCode[pos] != 0x5C:
+    if state.srcCharCodeAt(pos) != 0x5C:
         return False
 
     pos += 1
 
     if pos < maximum:
-        ch = state.srcCharCode[pos]
+        ch = state.srcCharCodeAt(pos)
+        assert ch is not None
 
         if ch < 256 and ESCAPED[ch] != 0:
             if not silent:
@@ -36,7 +37,7 @@ def escape(state: StateInline, silent: bool):
             pos += 1
             # skip leading whitespaces from next line
             while pos < maximum:
-                ch = state.srcCharCode[pos]
+                ch = state.srcCharCodeAt(pos)
                 if not isSpace(ch):
                     break
                 pos += 1

--- a/markdown_it/rules_inline/html_inline.py
+++ b/markdown_it/rules_inline/html_inline.py
@@ -18,11 +18,12 @@ def html_inline(state: StateInline, silent: bool):
 
     # Check start
     maximum = state.posMax
-    if state.srcCharCode[pos] != 0x3C or pos + 2 >= maximum:  # /* < */
+    if state.srcCharCodeAt(pos) != 0x3C or pos + 2 >= maximum:  # /* < */
         return False
 
     # Quick fail on second char
-    ch = state.srcCharCode[pos + 1]
+    ch = state.srcCharCodeAt(pos + 1)
+    assert ch is not None
     if (
         ch != 0x21
         and ch != 0x3F  # /* ! */

--- a/markdown_it/rules_inline/image.py
+++ b/markdown_it/rules_inline/image.py
@@ -15,10 +15,10 @@ def image(state: StateInline, silent: bool):
     max = state.posMax
 
     # /* ! */
-    if state.srcCharCode[state.pos] != 0x21:
+    if state.srcCharCodeAt(state.pos) != 0x21:
         return False
     # /* [ */
-    if state.pos + 1 < state.posMax and state.srcCharCode[state.pos + 1] != 0x5B:
+    if state.pos + 1 < state.posMax and state.srcCharCodeAt(state.pos + 1) != 0x5B:
         return False
 
     labelStart = state.pos + 2
@@ -30,7 +30,7 @@ def image(state: StateInline, silent: bool):
 
     pos = labelEnd + 1
     # /* ( */
-    if pos < max and state.srcCharCode[pos] == 0x28:
+    if pos < max and state.srcCharCodeAt(pos) == 0x28:
         #
         # Inline link
         #
@@ -39,7 +39,7 @@ def image(state: StateInline, silent: bool):
         #        ^^ skipping these spaces
         pos += 1
         while pos < max:
-            code = state.srcCharCode[pos]
+            code = state.srcCharCodeAt(pos)
             if not isSpace(code) and code != 0x0A:
                 break
             pos += 1
@@ -62,7 +62,7 @@ def image(state: StateInline, silent: bool):
         #                ^^ skipping these spaces
         start = pos
         while pos < max:
-            code = state.srcCharCode[pos]
+            code = state.srcCharCodeAt(pos)
             if not isSpace(code) and code != 0x0A:
                 break
             pos += 1
@@ -77,7 +77,7 @@ def image(state: StateInline, silent: bool):
             # [link](  <href>  "title"  )
             #                         ^^ skipping these spaces
             while pos < max:
-                code = state.srcCharCode[pos]
+                code = state.srcCharCodeAt(pos)
                 if not isSpace(code) and code != 0x0A:
                     break
                 pos += 1
@@ -85,7 +85,7 @@ def image(state: StateInline, silent: bool):
             title = ""
 
         # /* ) */
-        if pos >= max or state.srcCharCode[pos] != 0x29:
+        if pos >= max or state.srcCharCodeAt(pos) != 0x29:
             state.pos = oldPos
             return False
 
@@ -99,7 +99,7 @@ def image(state: StateInline, silent: bool):
             return False
 
         # /* [ */
-        if pos < max and state.srcCharCode[pos] == 0x5B:
+        if pos < max and state.srcCharCodeAt(pos) == 0x5B:
             start = pos + 1
             pos = state.md.helpers.parseLinkLabel(state, pos)
             if pos >= 0:

--- a/markdown_it/rules_inline/link.py
+++ b/markdown_it/rules_inline/link.py
@@ -14,7 +14,7 @@ def link(state: StateInline, silent: bool):
     start = state.pos
     parseReference = True
 
-    if state.srcCharCode[state.pos] != 0x5B:  # /* [ */
+    if state.srcCharCodeAt(state.pos) != 0x5B:  # /* [ */
         return False
 
     labelStart = state.pos + 1
@@ -26,7 +26,7 @@ def link(state: StateInline, silent: bool):
 
     pos = labelEnd + 1
 
-    if pos < maximum and state.srcCharCode[pos] == 0x28:  # /* ( */
+    if pos < maximum and state.srcCharCodeAt(pos) == 0x28:  # /* ( */
         #
         # Inline link
         #
@@ -38,7 +38,7 @@ def link(state: StateInline, silent: bool):
         #        ^^ skipping these spaces
         pos += 1
         while pos < maximum:
-            code = state.srcCharCode[pos]
+            code = state.srcCharCodeAt(pos)
             if not isSpace(code) and code != 0x0A:
                 break
             pos += 1
@@ -61,7 +61,7 @@ def link(state: StateInline, silent: bool):
             #                ^^ skipping these spaces
             start = pos
             while pos < maximum:
-                code = state.srcCharCode[pos]
+                code = state.srcCharCodeAt(pos)
                 if not isSpace(code) and code != 0x0A:
                     break
                 pos += 1
@@ -76,12 +76,12 @@ def link(state: StateInline, silent: bool):
                 # [link](  <href>  "title"  )
                 #                         ^^ skipping these spaces
                 while pos < maximum:
-                    code = state.srcCharCode[pos]
+                    code = state.srcCharCodeAt(pos)
                     if not isSpace(code) and code != 0x0A:
                         break
                     pos += 1
 
-        if pos >= maximum or state.srcCharCode[pos] != 0x29:  # /* ) */
+        if pos >= maximum or state.srcCharCodeAt(pos) != 0x29:  # /* ) */
             # parsing a valid shortcut link failed, fallback to reference
             parseReference = True
 
@@ -94,7 +94,7 @@ def link(state: StateInline, silent: bool):
         if "references" not in state.env:
             return False
 
-        if pos < maximum and state.srcCharCode[pos] == 0x5B:  # /* [ */
+        if pos < maximum and state.srcCharCodeAt(pos) == 0x5B:  # /* [ */
             start = pos + 1
             pos = state.md.helpers.parseLinkLabel(state, pos)
             if pos >= 0:

--- a/markdown_it/rules_inline/newline.py
+++ b/markdown_it/rules_inline/newline.py
@@ -11,7 +11,7 @@ def newline(state: StateInline, silent: bool):
     pos = state.pos
 
     # /* \n */
-    if state.srcCharCode[pos] != 0x0A:
+    if state.srcCharCodeAt(pos) != 0x0A:
         return False
 
     pmax = len(state.pending) - 1
@@ -36,7 +36,7 @@ def newline(state: StateInline, silent: bool):
     pos += 1
 
     # skip heading spaces for next line
-    while pos < maximum and isSpace(state.srcCharCode[pos]):
+    while pos < maximum and isSpace(state.srcCharCodeAt(pos)):
         pos += 1
 
     state.pos = pos

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -131,18 +131,18 @@ class StateInline(StateBase):
         left_flanking = True
         right_flanking = True
         maximum = self.posMax
-        marker = self.srcCharCode[start]
+        marker = self.srcCharCodeAt(start)
 
         # treat beginning of the line as a whitespace
-        lastChar = self.srcCharCode[start - 1] if start > 0 else 0x20
+        lastChar = self.srcCharCodeAt(start - 1) if start > 0 else 0x20
 
-        while pos < maximum and self.srcCharCode[pos] == marker:
+        while pos < maximum and self.srcCharCodeAt(pos) == marker:
             pos += 1
 
         count = pos - start
 
         # treat end of the line as a whitespace
-        nextChar = self.srcCharCode[pos] if pos < maximum else 0x20
+        nextChar = self.srcCharCodeAt(pos) if pos < maximum else 0x20
 
         isLastPunctChar = isMdAsciiPunct(lastChar) or isPunctChar(chr(lastChar))
         isNextPunctChar = isMdAsciiPunct(nextChar) or isPunctChar(chr(nextChar))

--- a/markdown_it/rules_inline/strikethrough.py
+++ b/markdown_it/rules_inline/strikethrough.py
@@ -6,7 +6,7 @@ from .state_inline import StateInline, Delimiter
 def tokenize(state: StateInline, silent: bool):
     """Insert each marker as a separate text token, and add it to delimiter list"""
     start = state.pos
-    marker = state.srcCharCode[start]
+    marker = state.srcCharCodeAt(start)
 
     if silent:
         return False

--- a/markdown_it/rules_inline/text.py
+++ b/markdown_it/rules_inline/text.py
@@ -42,7 +42,7 @@ def isTerminatorChar(ch):
 def text(state: StateInline, silent: bool, **args):
     pos = state.pos
     posMax = state.posMax
-    while (pos < posMax) and not isTerminatorChar(state.srcCharCode[pos]):
+    while (pos < posMax) and not isTerminatorChar(state.srcCharCodeAt(pos)):
         pos += 1
 
     if pos == state.pos:


### PR DESCRIPTION
Replaces use of `StateBase.srcCharCode` with the more JS-esque `StateBase.srcCharCodeAt` that can return `None`.

I didn't remove `StateBase.srcCharCode` for ease of migration because mdit-py-plugins use it. But did deprecate it.

Happy to hear what you think @chrisjsewell . Not sure if this is the solution or migration strategy you want, but it's something :smile: 

I haven't measured performance yet. We may want to do that if this is something we want to proceed with otherwise

EDIT: This PR is in response to discussion in https://github.com/executablebooks/markdown-it-py/pull/186