### PR TITLE
🔧 MAINTAIN: Add a profiler tox env

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ exclude .circleci
 exclude .circleci/config.yml
 exclude codecov.yml
 exclude .mypy.ini
+exclude profiler.py
 
 include LICENSE
 include LICENSE.markdown-it

--- a/profiler.py
+++ b/profiler.py
@@ -1,0 +1,19 @@
+"""A script for profiling.
+
+To generate and read results:
+  - `tox -e profile`
+  - `firefox .tox/prof/output.svg`
+"""
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+
+commonmark_spec = (
+    (Path(__file__).parent / "tests" / "test_cmark_spec" / "spec.md")
+    .read_bytes()
+    .decode()
+)
+
+# Run this a few times to emphasize over imports and other overhead above
+for _ in range(10):
+    MarkdownIt().render(commonmark_spec)

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,8 @@ benchmarking =
     psutil
     pytest
     pytest-benchmark~=3.2
+profiling =
+    gprof2dot
 
 [options.packages.find]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,16 @@ setenv =
 commands =
     clean: rm -rf docs/_build
     sphinx-build -nW --keep-going -b {posargs:html} docs/ docs/_build/{posargs:html}
+
+[testenv:profile]
+description = run profiler (use e.g. `firefox .tox/prof/output.svg` to open)
+extras = profiling
+allowlist_externals =
+    mkdir
+    dot
+commands =
+    mkdir -p "{toxworkdir}/prof"
+    python -m cProfile -o "{toxworkdir}/prof/output.pstats" profiler.py
+    gprof2dot -f pstats -o "{toxworkdir}/prof/output.dot" "{toxworkdir}/prof/output.pstats"
+    dot -Tsvg -o "{toxworkdir}/prof/output.svg" "{toxworkdir}/prof/output.dot"
+    python -c 'import pathlib; print("profiler svg output under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "prof" / "output.svg"))'


### PR DESCRIPTION
Now that mistletoe [beat us](https://github.com/executablebooks/markdown-it-py/pull/196/files) (congrats to them!) I was curious to see if there's any easy ways to improve our performance and regain the number one spot :smile: I came up with a profiler tox env and thought you may want to merge it to the repository?