### PR TITLE
Move from `attrs` to `dataclasses`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,3 @@ repos:
     rev: v0.812
     hooks:
     - id: mypy
-      additional_dependencies: [attrs]

--- a/markdown_it/_compat.py
+++ b/markdown_it/_compat.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import sys
+from typing import Any
+
+if sys.version_info >= (3, 10):
+    dataclass_kwargs: Mapping[str, Any] = {"slots": True}
+else:
+    dataclass_kwargs: Mapping[str, Any] = {}

--- a/markdown_it/ruler.py
+++ b/markdown_it/ruler.py
@@ -18,8 +18,10 @@ rules control use [[MarkdownIt.disable]], [[MarkdownIt.enable]] and
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, MutableMapping
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
-import attr
+
+from markdown_it._compat import dataclass_kwargs
 
 if TYPE_CHECKING:
     from markdown_it import MarkdownIt
@@ -50,12 +52,12 @@ class StateBase:
 RuleFunc = Callable
 
 
-@attr.s(slots=True)
+@dataclass(**dataclass_kwargs)
 class Rule:
-    name: str = attr.ib()
-    enabled: bool = attr.ib()
-    fn: RuleFunc = attr.ib(repr=False)
-    alt: list[str] = attr.ib()
+    name: str
+    enabled: bool
+    fn: RuleFunc = field(repr=False)
+    alt: list[str]
 
 
 class Ruler:
@@ -105,7 +107,7 @@ class Ruler:
         options = options or {}
         if index == -1:
             raise KeyError(f"Parser rule not found: {ruleName}")
-        self.__rules__[index].fn = fn
+        self.__rules__[index].fn = fn  # type: ignore[assignment]
         self.__rules__[index].alt = options.get("alt", [])
         self.__cache__ = None
 

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from collections import namedtuple
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING
+from dataclasses import dataclass
 
-import attr
-
+from .._compat import dataclass_kwargs
 from ..token import Token
 from ..ruler import StateBase
 from ..common.utils import isWhiteSpace, isPunctChar, isMdAsciiPunct
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
     from markdown_it import MarkdownIt
 
 
-@attr.s(slots=True)
+@dataclass(**dataclass_kwargs)
 class Delimiter:
     # Char code of the starting marker (number).
-    marker: int = attr.ib()
+    marker: int
 
     # Total length of these series of delimiters.
-    length: int = attr.ib()
+    length: int
 
     # An amount of characters before this one that's equivalent to
     # current one. In plain English: if this delimiter does not open
@@ -28,21 +28,21 @@ class Delimiter:
     #
     # Used to skip sequences like "*****" in one step, for 1st asterisk
     # value will be 0, for 2nd it's 1 and so on.
-    jump: int = attr.ib()
+    jump: int
 
     # A position of the token this delimiter corresponds to.
-    token: int = attr.ib()
+    token: int
 
     # If this delimiter is matched as a valid opener, `end` will be
     # equal to its position, otherwise it's `-1`.
-    end: int = attr.ib()
+    end: int
 
     # Boolean flags that determine if this delimiter could open or close
     # an emphasis.
-    open: bool = attr.ib()
-    close: bool = attr.ib()
+    open: bool
+    close: bool
 
-    level: bool = attr.ib(default=None)
+    level: bool | None = None
 
 
 Scanned = namedtuple("Scanned", ["can_open", "can_close", "length"])

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    attrs>=19,<22
     mdurl~=0.1
     typing_extensions>=3.7.4;python_version<'3.8'
 python_requires = >=3.7

--- a/tests/test_api/test_main/test_table_tokens.yml
+++ b/tests/test_api/test_main/test_table_tokens.yml
@@ -1,4 +1,4 @@
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -13,7 +13,7 @@
   nesting: 1
   tag: table
   type: table_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -28,7 +28,7 @@
   nesting: 1
   tag: thead
   type: thead_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -43,7 +43,7 @@
   nesting: 1
   tag: tr
   type: tr_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -56,10 +56,10 @@
   nesting: 1
   tag: th
   type: th_open
-- attrs: null
+- attrs: {}
   block: true
   children:
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: Heading 1
@@ -84,7 +84,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -97,7 +97,7 @@
   nesting: -1
   tag: th
   type: th_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -110,10 +110,10 @@
   nesting: 1
   tag: th
   type: th_open
-- attrs: null
+- attrs: {}
   block: true
   children:
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: Heading 2
@@ -138,7 +138,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -151,7 +151,7 @@
   nesting: -1
   tag: th
   type: th_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -164,7 +164,7 @@
   nesting: -1
   tag: tr
   type: tr_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -177,7 +177,7 @@
   nesting: -1
   tag: thead
   type: thead_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -192,7 +192,7 @@
   nesting: 1
   tag: tbody
   type: tbody_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -207,7 +207,7 @@
   nesting: 1
   tag: tr
   type: tr_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -220,10 +220,10 @@
   nesting: 1
   tag: td
   type: td_open
-- attrs: null
+- attrs: {}
   block: true
   children:
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: Cell 1
@@ -248,7 +248,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -261,7 +261,7 @@
   nesting: -1
   tag: td
   type: td_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -274,10 +274,10 @@
   nesting: 1
   tag: td
   type: td_open
-- attrs: null
+- attrs: {}
   block: true
   children:
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: Cell 2
@@ -302,7 +302,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -315,7 +315,7 @@
   nesting: -1
   tag: td
   type: td_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -328,7 +328,7 @@
   nesting: -1
   tag: tr
   type: tr_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -343,7 +343,7 @@
   nesting: 1
   tag: tr
   type: tr_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -356,10 +356,10 @@
   nesting: 1
   tag: td
   type: td_open
-- attrs: null
+- attrs: {}
   block: true
   children:
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: Cell 3
@@ -384,7 +384,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -397,7 +397,7 @@
   nesting: -1
   tag: td
   type: td_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -410,10 +410,10 @@
   nesting: 1
   tag: td
   type: td_open
-- attrs: null
+- attrs: {}
   block: true
   children:
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: Cell 4
@@ -438,7 +438,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -451,7 +451,7 @@
   nesting: -1
   tag: td
   type: td_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -464,7 +464,7 @@
   nesting: -1
   tag: tr
   type: tr_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -477,7 +477,7 @@
   nesting: -1
   tag: tbody
   type: tbody_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''

--- a/tests/test_api/test_token.py
+++ b/tests/test_api/test_token.py
@@ -9,7 +9,7 @@ def test_token():
         "type": "name",
         "tag": "tag",
         "nesting": 0,
-        "attrs": None,
+        "attrs": {},
         "map": None,
         "level": 0,
         "children": None,

--- a/tests/test_port/test_references/test_inline_definitions.yml
+++ b/tests/test_port/test_references/test_inline_definitions.yml
@@ -1,4 +1,4 @@
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -17,7 +17,7 @@
   nesting: 0
   tag: ''
   type: definition
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -32,7 +32,7 @@
   nesting: 1
   tag: ul
   type: bullet_list_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -47,7 +47,7 @@
   nesting: 1
   tag: li
   type: list_item_open
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -66,7 +66,7 @@
   nesting: 0
   tag: ''
   type: definition
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -79,7 +79,7 @@
   nesting: -1
   tag: li
   type: list_item_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''

--- a/tests/test_port/test_references/test_store_labels.yml
+++ b/tests/test_port/test_references/test_store_labels.yml
@@ -1,4 +1,4 @@
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -13,12 +13,11 @@
   nesting: 1
   tag: p
   type: paragraph_open
-- attrs: null
+- attrs: {}
   block: true
   children:
   - attrs:
-    - - href
-      - ijk
+      href: ijk
     block: false
     children: null
     content: ''
@@ -32,7 +31,7 @@
     nesting: 1
     tag: a
     type: link_open
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: a
@@ -45,7 +44,7 @@
     nesting: 0
     tag: ''
     type: text
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: ''
@@ -70,7 +69,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -83,7 +82,7 @@
   nesting: -1
   tag: p
   type: paragraph_close
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -98,17 +97,15 @@
   nesting: 1
   tag: p
   type: paragraph_open
-- attrs: null
+- attrs: {}
   block: true
   children:
   - attrs:
-    - - src
-      - ijk
-    - - alt
-      - ''
+      alt: ''
+      src: ijk
     block: false
     children:
-    - attrs: null
+    - attrs: {}
       block: false
       children: null
       content: a
@@ -144,7 +141,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''

--- a/tests/test_port/test_references/test_use_existing_env.yml
+++ b/tests/test_port/test_references/test_use_existing_env.yml
@@ -1,4 +1,4 @@
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''
@@ -13,12 +13,11 @@
   nesting: 1
   tag: p
   type: paragraph_open
-- attrs: null
+- attrs: {}
   block: true
   children:
   - attrs:
-    - - href
-      - abc
+      href: abc
     block: false
     children: null
     content: ''
@@ -31,7 +30,7 @@
     nesting: 1
     tag: a
     type: link_open
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: a
@@ -44,7 +43,7 @@
     nesting: 0
     tag: ''
     type: text
-  - attrs: null
+  - attrs: {}
     block: false
     children: null
     content: ''
@@ -69,7 +68,7 @@
   nesting: 0
   tag: ''
   type: inline
-- attrs: null
+- attrs: {}
   block: true
   children: null
   content: ''


### PR DESCRIPTION
### BREAKING CHANGES
- `Token.as_dict`  -- Moved to using a simple `dataclasses.asdict` call. This means that many keyword arguments are removed from the method. Output is also slightly different (see `.yml` test regression files in this PR).
- ~~`Token.copy` -- Moved from `attr.evolve` to a simple `copy.copy` call. The stdlib `copy.copy` call does quite literally what the docstring of `Token.copy` says which is "return a shallow copy of the instance". Does `attr.evolve` do something extra? Is there a chance someone relies on this extra behavior?~~ EDIT: Answering my own question: Without keyword arguments, `attr.evolve` seems doesn't seem to do anything that `copy.copy` doesn't. I don't think this is a breaking change.