### PR TITLE
🧪 TEST: Space in link destination generates `IndexError`

### DIFF
--- a/tests/test_port/fixtures/commonmark_extras.md
+++ b/tests/test_port/fixtures/commonmark_extras.md
@@ -663,3 +663,13 @@ Issue #772. Header rule should not interfere with html tags.
 ==
 </pre>
 .
+
+Issue #205.  Space in link destination generates IndexError
+.
+[Contact](http:// mail.com)
+
+[Contact](mailto: mail@mail.com)
+.
+<p>[Contact](http:// mail.com)</p>
+<p>[Contact](mailto: mail@mail.com)</p>
+.


### PR DESCRIPTION
Test case for [executablebooks/markdown-it-py:205](https://github.com/executablebooks/markdown-it-py/issues/205)

This test will be fixed by https://github.com/executablebooks/mdurl/pull/7
