### PR TITLE
♻️ REFACTOR: Move `Token` to `dataclass`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ compare = [
 linkify = ["linkify-it-py~=1.0"]
 plugins = ["mdit-py-plugins"]
 rtd = [
+    "attrs",
     "myst-parser",
     "pyyaml",
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 keywords = ["markdown", "lexer", "parser", "commonmark", "markdown-it"]
 requires-python = ">=3.7"
 dependencies = [
-    "attrs>=19,<22",
     "mdurl~=0.1",
     "typing_extensions>=3.7.4;python_version<'3.8'",
 ]


### PR DESCRIPTION
In order to remove `attrs` dependency.