### PR TITLE
⬆️ UPGRADE: Allow linkify-it-py v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ compare = [
     "mistune~=2.0.2",
     "panflute~=2.1.3",
 ]
-linkify = ["linkify-it-py~=1.0"]
+linkify = ["linkify-it-py>=1,<3"]
 plugins = ["mdit-py-plugins"]
 rtd = [
     "attrs",


### PR DESCRIPTION
 A port of linkify-it 4.0.0 ([changelog here](https://github.com/markdown-it/linkify-it/blob/master/CHANGELOG.md#400--2022-04-22)) which makes a couple fixes and adds a new method