### PR TITLE
Add shell completions by shtab

### DIFF
--- a/markdown_it/_shtab.py
+++ b/markdown_it/_shtab.py
@@ -1,0 +1,10 @@
+from argparse import Action, ArgumentParser
+from typing import Any, Dict, List
+
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser: ArgumentParser, *args: List[Any], **kwargs: Dict[str, Any]):
+    Action.complete = None  # type: ignore
+    return parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ benchmarking = [
     "pytest-benchmark~=3.2",
 ]
 profiling = ["gprof2dot"]
+completion = ["shtab"]
 
 [project.scripts]
 markdown-it = "markdown_it.cli.parse:main"


### PR DESCRIPTION
Like <https://github.com/executablebooks/mdformat/pull/360>

```sh
markdown-it --print-completion bash | sudo tee /usr/share/bash-completion/completions/markdown-it
markdown-it --print-completion tcsh | sudo tee /etc/profile.d/markdown-it.completion.csh
markdown-it --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_markdown-it
```
