### PR TITLE
⬆️ UPGRADE: Allow up-to-date pytest-benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ testing = [
 benchmarking = [
     "psutil",
     "pytest",
-    "pytest-benchmark~=3.2",
+    "pytest-benchmark",
 ]
 profiling = ["gprof2dot"]
 


### PR DESCRIPTION
Old versions of pytest-benchmark rely on the `py` package but don't list it as a dependency.

This fixes the broken `continuous-integration / benchmark` check.