### PR TITLE
📚 DOCS: Update the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,9 @@ from mdit_py_plugins.front_matter import front_matter_plugin
 from mdit_py_plugins.footnote import footnote_plugin
 
 md = (
-    MarkdownIt()
+    MarkdownIt('commonmark' ,{'breaks':True,'html':True})
     .use(front_matter_plugin)
     .use(footnote_plugin)
-    .disable('image')
     .enable('table')
 )
 text = ("""


### PR DESCRIPTION
It is a very bad idea to `.disable('image')` in the example , most newbies just copy the example to test, by  `.disable('image')` causes unnecessary problem for them. I suffered the problem. So let's make a more user-friendly example.