### PR TITLE
fix: specify release bound for compat test

### DIFF
--- a/markdown_it/_compat.py
+++ b/markdown_it/_compat.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import sys
 from typing import Any
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10, 0, "release"):
     DATACLASS_KWARGS: Mapping[str, Any] = {"slots": True}
 else:
     DATACLASS_KWARGS: Mapping[str, Any] = {}

--- a/markdown_it/_compat.py
+++ b/markdown_it/_compat.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import sys
 from typing import Any
 
-if sys.version_info >= (3, 10, 0, "release"):
+if sys.version_info >= (3, 10, 0, "final"):
     DATACLASS_KWARGS: Mapping[str, Any] = {"slots": True}
 else:
     DATACLASS_KWARGS: Mapping[str, Any] = {}


### PR DESCRIPTION
I didn't bisect to find when 3.10 adds the `slots` argument; I know it's in the release itself, and I don't think we need to be *that* careful to provide features to old alpha/beta/rc releases.