### PR TITLE
👌 Centralise indented code block test

### DIFF
--- a/markdown_it/rules_block/blockquote.py
+++ b/markdown_it/rules_block/blockquote.py
@@ -18,8 +18,7 @@ def blockquote(state: StateBlock, startLine: int, endLine: int, silent: bool) ->
     pos = state.bMarks[startLine] + state.tShift[startLine]
     max = state.eMarks[startLine]
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if (state.sCount[startLine] - state.blkIndent) >= 4:
+    if state.is_code_block(startLine):
         return False
 
     # check the block quote marker

--- a/markdown_it/rules_block/code.py
+++ b/markdown_it/rules_block/code.py
@@ -9,7 +9,7 @@ LOGGER = logging.getLogger(__name__)
 def code(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool:
     LOGGER.debug("entering code: %s, %s, %s, %s", state, startLine, endLine, silent)
 
-    if state.sCount[startLine] - state.blkIndent < 4:
+    if not state.is_code_block(startLine):
         return False
 
     last = nextLine = startLine + 1
@@ -19,7 +19,7 @@ def code(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool:
             nextLine += 1
             continue
 
-        if state.sCount[nextLine] - state.blkIndent >= 4:
+        if state.is_code_block(nextLine):
             nextLine += 1
             last = nextLine
             continue

--- a/markdown_it/rules_block/fence.py
+++ b/markdown_it/rules_block/fence.py
@@ -13,8 +13,7 @@ def fence(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
 
     if pos + 3 > maximum:
@@ -72,8 +71,7 @@ def fence(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool
         except IndexError:
             break
 
-        if state.sCount[nextLine] - state.blkIndent >= 4:
-            # closing fence should be indented less than 4 spaces
+        if state.is_code_block(nextLine):
             continue
 
         pos = state.skipChars(pos, marker)

--- a/markdown_it/rules_block/heading.py
+++ b/markdown_it/rules_block/heading.py
@@ -15,8 +15,7 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bo
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
 
     ch: int | None = state.srcCharCode[pos]

--- a/markdown_it/rules_block/hr.py
+++ b/markdown_it/rules_block/hr.py
@@ -16,8 +16,7 @@ def hr(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool:
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
 
     try:

--- a/markdown_it/rules_block/html_block.py
+++ b/markdown_it/rules_block/html_block.py
@@ -38,8 +38,7 @@ def html_block(state: StateBlock, startLine: int, endLine: int, silent: bool) ->
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
 
     if not state.md.options.get("html", None):

--- a/markdown_it/rules_block/lheading.py
+++ b/markdown_it/rules_block/lheading.py
@@ -15,8 +15,7 @@ def lheading(state: StateBlock, startLine: int, endLine: int, silent: bool) -> b
     ruler: Ruler = state.md.block.ruler
     terminatorRules = ruler.getRules("paragraph")
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
 
     oldParentType = state.parentType

--- a/markdown_it/rules_block/list.py
+++ b/markdown_it/rules_block/list.py
@@ -102,8 +102,7 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool) ->
     isTerminatingParagraph = False
     tight = True
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
 
     # Special case:
@@ -295,8 +294,7 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool) ->
         if state.sCount[nextLine] < state.blkIndent:
             break
 
-        # if it's indented more than 3 spaces, it should be a code block
-        if state.sCount[startLine] - state.blkIndent >= 4:
+        if state.is_code_block(startLine):
             break
 
         # fail if terminating block found

--- a/markdown_it/rules_block/reference.py
+++ b/markdown_it/rules_block/reference.py
@@ -16,8 +16,7 @@ def reference(state: StateBlock, startLine: int, _endLine: int, silent: bool) ->
     maximum = state.eMarks[startLine]
     nextLine = startLine + 1
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
 
     if state.srcCharCode[pos] != 0x5B:  # /* [ */

--- a/markdown_it/rules_block/state_block.py
+++ b/markdown_it/rules_block/state_block.py
@@ -116,6 +116,9 @@ class StateBlock(StateBase):
 
         self.lineMax = len(self.bMarks) - 1  # don't count last fake line
 
+        # pre-check if code blocks are enabled, to speed up is_code_block method
+        self._code_enabled = "code" in self.md["block"].ruler.get_active_rules()
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}"
@@ -228,3 +231,9 @@ class StateBlock(StateBase):
             i += 1
 
         return "".join(queue)
+
+    def is_code_block(self, line: int) -> bool:
+        """Check if line is a code block,
+        i.e. the code block rule is enabled and text is indented by more than 3 spaces.
+        """
+        return self._code_enabled and (self.sCount[line] - self.blkIndent) >= 4

--- a/markdown_it/rules_block/table.py
+++ b/markdown_it/rules_block/table.py
@@ -61,8 +61,7 @@ def table(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool
     if state.sCount[nextLine] < state.blkIndent:
         return False
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[nextLine] - state.blkIndent >= 4:
+    if state.is_code_block(nextLine):
         return False
 
     # first character of the second line should be '|', '-', ':',
@@ -126,7 +125,7 @@ def table(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool
     lineText = getLine(state, startLine).strip()
     if "|" not in lineText:
         return False
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if state.is_code_block(startLine):
         return False
     columns = escapedSplit(lineText)
     if columns and columns[0] == "":
@@ -192,7 +191,7 @@ def table(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool
         lineText = getLine(state, nextLine).strip()
         if not lineText:
             break
-        if state.sCount[nextLine] - state.blkIndent >= 4:
+        if state.is_code_block(nextLine):
             break
         columns = escapedSplit(lineText)
         if columns and columns[0] == "":

--- a/tests/test_port/fixtures/disable_code_block.md
+++ b/tests/test_port/fixtures/disable_code_block.md
@@ -1,0 +1,69 @@
+indent paragraph
+.
+    This is a paragraph,
+    with multiple lines.
+
+    This paragraph
+has variable indents,
+      like this.
+.
+<p>This is a paragraph,
+with multiple lines.</p>
+<p>This paragraph
+has variable indents,
+like this.</p>
+.
+
+indent in HTML
+.
+<div>
+
+    Paragraph
+
+</div>
+.
+<div>
+<p>Paragraph</p>
+</div>
+.
+
+indent fence
+.
+        ```python
+        def foo():
+            pass
+        ```
+.
+<pre><code class="language-python">def foo():
+    pass
+</code></pre>
+.
+
+indent heading
+.
+     # Heading
+.
+<h1>Heading</h1>
+.
+
+indent table
+.
+     | foo | bar |
+     | --- | --- |
+     | baz | bim |
+.
+<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>baz</td>
+<td>bim</td>
+</tr>
+</tbody>
+</table>
+.

--- a/tests/test_port/test_fixtures.py
+++ b/tests/test_port/test_fixtures.py
@@ -106,6 +106,17 @@ def test_strikethrough(line, title, input, expected):
 
 @pytest.mark.parametrize(
     "line,title,input,expected",
+    read_fixture_file(FIXTURE_PATH.joinpath("disable_code_block.md")),
+)
+def test_disable_code_block(line, title, input, expected):
+    md = MarkdownIt().enable("table").disable("code")
+    text = md.render(input)
+    print(text.rstrip())
+    assert text.rstrip() == expected.rstrip()
+
+
+@pytest.mark.parametrize(
+    "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("issue-fixes.md")),
 )
 def test_issue_fixes(line, title, input, expected):


### PR DESCRIPTION
For CommonMark, the presence of indented code blocks prevent any other block element from having an indent of greater than 4 spaces.
Certain Markdown flavors and derivatives, such as mdx and djot, disable these code blocks though, since it is more common to use code fences and/or arbitrary indenting is desirable.
Currently, disabling code blocks does not remove the indent limitation, since most block elements have the 3 space limitation hard-coded.
This commit therefore centralises the logic of applying this limitation, and only applies it when indented code blocks are enabled.
Note, this is a potential breaking change and divergence from upstream markdown-it, for this niche case, but I feel makes sense and could even be upstreamed.