### PR TITLE
🧪 CI: Add fuzzing workflow for PRs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         oss-fuzz-project-name: 'markdown-it-py'
         language: python
-        fuzz-seconds: 100
+        fuzz-seconds: 60
     - name: Upload Crash
       uses: actions/upload-artifact@v3
       if: failure() && steps.build.outcome == 'success'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,34 @@
+name: fuzzing
+
+# This action runs fuzzing for a brief period of time,
+# only aginst the actual code added in the PR.
+# It is intended a relatively quick check,
+# to guard against code introducing crashes in the Markdown parsing,
+# which should in principle always run against any text input.
+# See: https://google.github.io/oss-fuzz/getting-started/continuous-integration/#how-it-works
+
+on:
+  pull_request:
+
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'markdown-it-py'
+        language: python
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'markdown-it-py'
+        language: python
+        fuzz-seconds: 100
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   test-plugins:
 


### PR DESCRIPTION
This action runs fuzzing for a brief period of time, only against the actual code added in the PR.
It is intended as a relatively quick check,
to guard against code introducing crashes in the Markdown parsing, which should in principle always run against any text input. See: https://google.github.io/oss-fuzz/getting-started/continuous-integration/#how-it-works