### PR TITLE
⬆️ Drop Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['pypy-3.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['pypy-3.8', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -47,10 +47,10 @@ jobs:
       run: |
         pytest tests/ --cov=markdown_it --cov-report=xml --cov-report=term-missing
     - name: Upload to Codecov
-      if: matrix.python-version == '3.7' && github.repository == 'executablebooks/markdown-it-py'
+      if: matrix.python-version == '3.8' && github.repository == 'executablebooks/markdown-it-py'
       uses: codecov/codecov-action@v3
       with:
-        name: markdown-it-py-pytests-py3.7
+        name: markdown-it-py-pytests
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: 3
+  version: "3.8"
   install:
       - method: pip
         path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ html_css_files = ["custom.css"]
 
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.7", None),
+    "python": ("https://docs.python.org/3.8", None),
     "mdit-py-plugins": ("https://mdit-py-plugins.readthedocs.io/en/latest/", None),
 }
 

--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -9,16 +9,11 @@ from __future__ import annotations
 
 from collections.abc import MutableMapping, Sequence
 import inspect
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Protocol
 
 from .common.utils import escapeHtml, unescapeAll
 from .token import Token
 from .utils import OptionsDict
-
-try:
-    from typing import Protocol
-except ImportError:  # Python <3.8 doesn't have `Protocol` in the stdlib
-    from typing_extensions import Protocol  # type: ignore
 
 
 class RendererProtocol(Protocol):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -25,10 +24,9 @@ classifiers = [
     "Topic :: Text Processing :: Markup",
 ]
 keywords = ["markdown", "lexer", "parser", "commonmark", "markdown-it"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "mdurl~=0.1",
-    "typing_extensions>=3.7.4;python_version<'3.8'",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,18 @@
 # then run `tox` or `tox -- {pytest args}`
 # run in parallel using `tox -p`
 [tox]
-envlist = py37
+envlist = py38
 
 [testenv]
 usedevelop = true
 
-[testenv:py{37,38,39,310,311}]
+[testenv:py{38,39,310,311}]
 extras =
     linkify
     testing
 commands = pytest {posargs:tests/}
 
-[testenv:py{37,38,39,310,311}-plugins]
+[testenv:py{38,39,310,311}-plugins]
 extras = testing
 changedir = {envtmpdir}
 allowlist_externals =
@@ -27,11 +27,11 @@ commands_pre =
 commands =
     pytest {posargs}
 
-[testenv:py{37,38,39}-bench-core]
+[testenv:py{38,39,310,311}-bench-core]
 extras = benchmarking
 commands = pytest benchmarking/bench_core.py {posargs}
 
-[testenv:py{37,38}-bench-packages]
+[testenv:py{38,39,310,311}-bench-packages]
 extras = benchmarking,compare
 commands = pytest benchmarking/bench_packages.py {posargs}
 


### PR DESCRIPTION
Python 3.7 is end-of-life on 2023-06-27 https://devguide.python.org/versions/