### PR TITLE
🐛 FIX: numeric character reference passing

### DIFF
--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -139,7 +139,7 @@ def stripEscape(string: str) -> str:
 def escapeHtml(raw: str) -> str:
     """Replace special characters "&", "<", ">" and '"' to HTML-safe sequences."""
     # like html.escape, but without escaping single quotes
-    raw = raw.replace("&", "&amp;") # Must be done first!
+    raw = raw.replace("&", "&amp;")  # Must be done first!
     raw = raw.replace("<", "&lt;")
     raw = raw.replace(">", "&gt;")
     raw = raw.replace('"', "&quot;")

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -10,15 +10,15 @@ import pytest
 from markdown_it import MarkdownIt
 
 TESTS = {
-    55363: ">```\n>",
-    55367: ">-\n>\n>",
-    # 55371: "[](so&#4»0;!"  TODO this did not fail
-    # 55401: "?c_" * 100_000  TODO this did not fail
+    55363: (">```\n>", "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n"),
+    55367: (">-\n>\n>", "<blockquote>\n<ul>\n<li></li>\n</ul>\n</blockquote>\n"),
+    55371: ("[](so&#4H0;!", "<p>[](so&amp;#4H0;!</p>\n"),
+    # 55401: (("?c_" * 100000) + "c_", ""),  TODO this does not fail, just takes a long time
 }
 
 
-@pytest.mark.parametrize("raw_input", TESTS.values(), ids=TESTS.keys())
-def test_fuzzing(raw_input):
+@pytest.mark.parametrize("raw_input,expected", TESTS.values(), ids=TESTS.keys())
+def test_fuzzing(raw_input, expected):
     md = MarkdownIt()
     md.parse(raw_input)
-    print(md.render(raw_input))
+    assert md.render(raw_input) == expected

--- a/tests/test_port/fixtures/issue-fixes.md
+++ b/tests/test_port/fixtures/issue-fixes.md
@@ -45,3 +45,12 @@ Fix CVE-2023-26303
 <p><img src="%5B" alt="
 " /></p>
 .
+
+Fix parsing of incorrect numeric character references
+.
+[](&#X22y;) &#X22y;
+[](&#35y;) &#35y;
+.
+<p><a href="&amp;#X22y;"></a> &amp;#X22y;
+<a href="&amp;#35y;"></a> &amp;#35y;</p>
+.


### PR DESCRIPTION
Fix issue with incorrect determination of a numeric character reference, and subsequent failure to convert to an integer code.

From https://github.com/google/oss-fuzz/tree/master/projects/markdown-it-py, fixes issue 55371

This also essentially fixes a bug in upstream, see https://github.com/markdown-it/markdown-it/issues/935
