### PR TITLE
🐛 Fix: tab preventing paragraph continuation in lists

### DIFF
--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -1,7 +1,7 @@
 - package: markdown-it/markdown-it
-  version: 12.3.0
-  commit: 2e31d3430187d2eee1ba120c954783eebb93b4e8
-  date: Dec 9, 2021
+  version: 12.3.1
+  commit: 76469e83dc1a1e3ed943b483b554003a666bddf7
+  date: Jan 7, 2022
   notes:
     - Rename variables that use python built-in names, e.g.
       - `max` -> `maximum`

--- a/markdown_it/rules_block/list.py
+++ b/markdown_it/rules_block/list.py
@@ -130,7 +130,7 @@ def list_block(state: StateBlock, startLine: int, endLine: int, silent: bool) ->
     if (
         silent
         and state.parentType == "paragraph"
-        and state.tShift[startLine] >= state.blkIndent
+        and state.sCount[startLine] >= state.blkIndent
     ):
         isTerminatingParagraph = True
 

--- a/tests/test_port/fixtures/commonmark_extras.md
+++ b/tests/test_port/fixtures/commonmark_extras.md
@@ -166,6 +166,27 @@ Regression test (code block + regular paragraph)
 </blockquote>
 .
 
+Regression test (tabs in lists, #830)
+.
+1. asd
+    2. asd
+
+---
+
+1. asd
+	2. asd
+.
+<ol>
+<li>asd
+2. asd</li>
+</ol>
+<hr />
+<ol>
+<li>asd
+2. asd</li>
+</ol>
+.
+
 Blockquotes inside indented lists should terminate correctly
 .
    - a


### PR DESCRIPTION
Implements upstream: https://github.com/markdown-it/markdown-it/commit/1cd8a5143b22967a7583bba19678900efdf72adf