### PR TITLE
♻️ Refactor: Add linkifier rule to inline chain for full links

### DIFF
--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -304,3 +304,15 @@ def normalizeReference(string: str) -> str:
     # most notably, `__proto__`)
     #
     return string.lower().upper()
+
+
+LINK_OPEN_RE = re.compile(r"^<a[>\s]", flags=re.IGNORECASE)
+LINK_CLOSE_RE = re.compile(r"^</a\s*>", flags=re.IGNORECASE)
+
+
+def isLinkOpen(string: str) -> bool:
+    return bool(LINK_OPEN_RE.search(string))
+
+
+def isLinkClose(string: str) -> bool:
+    return bool(LINK_CLOSE_RE.search(string))

--- a/markdown_it/parser_inline.py
+++ b/markdown_it/parser_inline.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 # Parser rules
 _rules: list[tuple[str, RuleFunc]] = [
     ("text", rules_inline.text),
+    ("linkify", rules_inline.linkify),
     ("newline", rules_inline.newline),
     ("escape", rules_inline.escape),
     ("backticks", rules_inline.backtick),

--- a/markdown_it/presets/__init__.py
+++ b/markdown_it/presets/__init__.py
@@ -21,7 +21,7 @@ class gfm_like:  # noqa: N801
         config = commonmark.make()
         config["components"]["core"]["rules"].append("linkify")
         config["components"]["block"]["rules"].append("table")
-        config["components"]["inline"]["rules"].append("strikethrough")
+        config["components"]["inline"]["rules"].extend(["strikethrough", "linkify"])
         config["components"]["inline"]["rules2"].append("strikethrough")
         config["options"]["linkify"] = True
         config["options"]["html"] = True

--- a/markdown_it/rules_inline/__init__.py
+++ b/markdown_it/rules_inline/__init__.py
@@ -3,6 +3,7 @@ __all__ = (
     "text",
     "fragments_join",
     "link_pairs",
+    "linkify",
     "escape",
     "newline",
     "backtick",
@@ -24,6 +25,7 @@ from .fragments_join import fragments_join
 from .html_inline import html_inline
 from .image import image
 from .link import link
+from .linkify import linkify
 from .newline import newline
 from .state_inline import StateInline
 from .text import text

--- a/markdown_it/rules_inline/html_inline.py
+++ b/markdown_it/rules_inline/html_inline.py
@@ -1,5 +1,6 @@
 # Process html tags
 from ..common.html_re import HTML_TAG_RE
+from ..common.utils import isLinkClose, isLinkOpen
 from .state_inline import StateInline
 
 
@@ -32,6 +33,11 @@ def html_inline(state: StateInline, silent: bool) -> bool:
     if not silent:
         token = state.push("html_inline", "", 0)
         token.content = state.src[pos : pos + len(match.group(0))]
+
+        if isLinkOpen(token.content):
+            state.linkLevel += 1
+        if isLinkClose(token.content):
+            state.linkLevel -= 1
 
     state.pos += len(match.group(0))
     return True

--- a/markdown_it/rules_inline/link.py
+++ b/markdown_it/rules_inline/link.py
@@ -140,7 +140,9 @@ def link(state: StateInline, silent: bool) -> bool:
         if label and state.md.options.get("store_labels", False):
             token.meta["label"] = label
 
+        state.linkLevel += 1
         state.md.inline.tokenize(state)
+        state.linkLevel -= 1
 
         token = state.push("link_close", "a", -1)
 

--- a/markdown_it/rules_inline/linkify.py
+++ b/markdown_it/rules_inline/linkify.py
@@ -1,0 +1,61 @@
+"""Process links like https://example.org/"""
+import re
+
+from .state_inline import StateInline
+
+# RFC3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+SCHEME_RE = re.compile(r"(?:^|[^a-z0-9.+-])([a-z][a-z0-9.+-]*)$", re.IGNORECASE)
+
+
+def linkify(state: StateInline, silent: bool) -> bool:
+    """Rule for identifying plain-text links."""
+    if not state.md.options.linkify:
+        return False
+    if state.linkLevel > 0:
+        return False
+    if not state.md.linkify:
+        raise ModuleNotFoundError("Linkify enabled but not installed.")
+
+    pos = state.pos
+    maximum = state.posMax
+
+    if (
+        (pos + 3) > maximum
+        or state.src[pos] != ":"
+        or state.src[pos + 1] != "/"
+        or state.src[pos + 2] != "/"
+    ):
+        return False
+
+    if not (match := SCHEME_RE.match(state.pending)):
+        return False
+
+    proto = match.group(1)
+    if not (link := state.md.linkify.match_at_start(state.src[pos - len(proto) :])):
+        return False
+    url: str = link.url
+
+    # disallow '*' at the end of the link (conflicts with emphasis)
+    url = url.rstrip("*")
+
+    full_url = state.md.normalizeLink(url)
+    if not state.md.validateLink(full_url):
+        return False
+
+    if not silent:
+        state.pending = state.pending[: -len(proto)]
+
+        token = state.push("link_open", "a", 1)
+        token.attrs = {"href": full_url}
+        token.markup = "linkify"
+        token.info = "auto"
+
+        token = state.push("text", "", 0)
+        token.content = state.md.normalizeLinkText(url)
+
+        token = state.push("link_close", "a", -1)
+        token.markup = "linkify"
+        token.info = "auto"
+
+    state.pos += len(url) - len(proto)
+    return True

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -70,6 +70,10 @@ class StateInline(StateBase):
         self.backticks: dict[int, int] = {}
         self.backticksScanned = False
 
+        # Counter used to disable inline linkify-it execution
+        # inside <a> and markdown links
+        self.linkLevel = 0
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}"

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -30,6 +30,7 @@ def test_get_rules():
         ],
         "inline": [
             "text",
+            "linkify",
             "newline",
             "escape",
             "backticks",

--- a/tests/test_port/fixtures/linkify.md
+++ b/tests/test_port/fixtures/linkify.md
@@ -29,6 +29,84 @@ don't touch text in html <a> tags
 <p><a href="https://example.com">https://example.com</a></p>
 .
 
+entities inside raw links
+.
+https://example.com/foo&amp;bar
+.
+<p><a href="https://example.com/foo&amp;amp;bar">https://example.com/foo&amp;amp;bar</a></p>
+.
+
+
+emphasis inside raw links (asterisk, can happen in links with params)
+.
+https://example.com/foo*bar*baz
+.
+<p><a href="https://example.com/foo*bar*baz">https://example.com/foo*bar*baz</a></p>
+.
+
+
+emphasis inside raw links (underscore)
+.
+http://example.org/foo._bar_-_baz
+.
+<p><a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a></p>
+.
+
+
+backticks inside raw links
+.
+https://example.com/foo`bar`baz
+.
+<p><a href="https://example.com/foo%60bar%60baz">https://example.com/foo`bar`baz</a></p>
+.
+
+
+links inside raw links
+.
+https://example.com/foo[123](456)bar
+.
+<p><a href="https://example.com/foo%5B123%5D(456)bar">https://example.com/foo[123](456)bar</a></p>
+.
+
+
+escapes not allowed at the start
+.
+\https://example.com
+.
+<p>\https://example.com</p>
+.
+
+
+escapes not allowed at comma
+.
+https\://example.com
+.
+<p>https://example.com</p>
+.
+
+
+escapes not allowed at slashes
+.
+https:\//aa.org https://bb.org
+.
+<p>https://aa.org <a href="https://bb.org">https://bb.org</a></p>
+.
+
+
+fuzzy link shouldn't match cc.org
+.
+https:/\/cc.org
+.
+<p>https://cc.org</p>
+.
+
+
+bold links (exclude markup of pairs from link tail)
+.
+**http://example.com/foobar**
+.
+<p><strong><a href="http://example.com/foobar">http://example.com/foobar</a></strong></p>
+.
 
 match links without protocol
 .
@@ -37,6 +115,35 @@ www.example.org
 <p><a href="http://www.example.org">www.example.org</a></p>
 .
 
+coverage, prefix not valid
+.
+http:/example.com/
+.
+<p>http:/example.com/</p>
+.
+
+
+coverage, negative link level
+.
+</a>[https://example.com](https://example.com)
+.
+<p></a><a href="https://example.com"><a href="https://example.com">https://example.com</a></a></p>
+.
+
+
+emphasis with '*', real link:
+.
+http://cdecl.ridiculousfish.com/?q=int+%28*f%29+%28float+*%29%3B
+.
+<p><a href="http://cdecl.ridiculousfish.com/?q=int+%28*f%29+%28float+*%29%3B">http://cdecl.ridiculousfish.com/?q=int+(*f)+(float+*)%3B</a></p>
+.
+
+emphasis with '_', real link:
+.
+https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf
+.
+<p><a href="https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf">https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf</a></p>
+.
 
 emails
 .


### PR DESCRIPTION
Fixes collision of emphasis and linkifier (so `http://example.org/foo._bar_-_baz`
  is now a single link, not emphasized). Emails and fuzzy links are not affected by this.

Implements upstream: https://github.com/markdown-it/markdown-it/commit/6b58ec4245abe2e293c79bd7daabf4543ef46399