### PR TITLE
♻️ Parse entities to `text_special` token

### DIFF
--- a/tests/test_port/fixtures/smartquotes.md
+++ b/tests/test_port/fixtures/smartquotes.md
@@ -177,3 +177,16 @@ Should be escapable:
 <p>&quot;foo&quot;</p>
 <p>&quot;foo&quot;</p>
 .
+
+Should not replace entities:
+.
+&quot;foo&quot;
+
+&quot;foo"
+
+"foo&quot;
+.
+<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>
+.

--- a/tests/test_port/fixtures/typographer.md
+++ b/tests/test_port/fixtures/typographer.md
@@ -130,3 +130,10 @@ regression tests for #624
 <p>1–2–3</p>
 <p>1 – – 3</p>
 .
+
+shouldn't replace entities
+.
+&#40;c) (c&#41; (c)
+.
+<p>(c) (c) ©</p>
+.


### PR DESCRIPTION
Rather than adding directly to text.
The `text_join` core rule then joins it to the text later, but after typographic rules have been applied.

Implements upstream: https://github.com/markdown-it/markdown-it/commita/3fc0deb38b5a8b2eb8f46c727cc4e299e5ae5f9c