### PR TITLE
‼️ Remove (p) => § replacement in typographer

### DIFF
--- a/markdown_it/port.yaml
+++ b/markdown_it/port.yaml
@@ -1,7 +1,7 @@
 - package: markdown-it/markdown-it
-  version: 12.3.2
-  commit: d72c68b520cedacae7878caa92bf7fe32e3e0e6f
-  date: Jan 8, 2022
+  version: 13.0.1
+  commit: e843acc9edad115cbf8cf85e676443f01658be08
+  date: May 3, 2022
   notes:
     - Rename variables that use python built-in names, e.g.
       - `max` -> `maximum`

--- a/markdown_it/rules_core/replacements.py
+++ b/markdown_it/rules_core/replacements.py
@@ -3,7 +3,6 @@
 * ``(c)``, ``(C)`` → ©
 * ``(tm)``, ``(TM)`` → ™
 * ``(r)``, ``(R)`` → ®
-* ``(p)``, ``(P)`` → §
 * ``+-`` → ±
 * ``...`` → …
 * ``?....`` → ?..
@@ -26,15 +25,15 @@ LOGGER = logging.getLogger(__name__)
 
 # TODO:
 # - fractionals 1/2, 1/4, 3/4 -> ½, ¼, ¾
-# - miltiplication 2 x 4 -> 2 × 4
+# - multiplication 2 x 4 -> 2 × 4
 
 RARE_RE = re.compile(r"\+-|\.\.|\?\?\?\?|!!!!|,,|--")
 
 # Workaround for phantomjs - need regex without /g flag,
 # or root check will fail every second time
-# SCOPED_ABBR_TEST_RE = r"\((c|tm|r|p)\)"
+# SCOPED_ABBR_TEST_RE = r"\((c|tm|r)\)"
 
-SCOPED_ABBR_RE = re.compile(r"\((c|tm|r|p)\)", flags=re.IGNORECASE)
+SCOPED_ABBR_RE = re.compile(r"\((c|tm|r)\)", flags=re.IGNORECASE)
 
 PLUS_MINUS_RE = re.compile(r"\+-")
 
@@ -53,7 +52,7 @@ EN_DASH_RE = re.compile(r"(^|\s)--(?=\s|$)", flags=re.MULTILINE)
 EN_DASH_INDENT_RE = re.compile(r"(^|[^-\s])--(?=[^-\s]|$)", flags=re.MULTILINE)
 
 
-SCOPED_ABBR = {"c": "©", "r": "®", "p": "§", "tm": "™"}
+SCOPED_ABBR = {"c": "©", "r": "®", "tm": "™"}
 
 
 def replaceFn(match: re.Match[str]) -> str:

--- a/tests/test_port/fixtures/typographer.md
+++ b/tests/test_port/fixtures/typographer.md
@@ -41,15 +41,6 @@ trademark
 <p>™ ™</p>
 .
 
-
-paragraph
-.
-(p) (P)
-.
-<p>§ §</p>
-.
-
-
 plus-minus
 .
 +-5


### PR DESCRIPTION
`(p)` is no longer replaced with § by typographer (conflicts with ℗)

Implements upstream: https://github.com/markdown-it/markdown-it/commit/f52351499be1e6c838110c31e07154cce1d91d47