### PR TITLE
📚 Fix CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Big thanks to the authors of [markdown-it]:
 
 Also [John MacFarlane](https://github.com/jgm) for his work on the CommonMark spec and reference implementations.
 
-[github-ci]: https://github.com/executablebooks/markdown-it-py/workflows/Python%20package/badge.svg?branch=master
+[github-ci]: https://github.com/executablebooks/markdown-it-py/actions/workflows/tests.yml/badge.svg?branch=master
 [github-link]: https://github.com/executablebooks/markdown-it-py
 [pypi-badge]: https://img.shields.io/pypi/v/markdown-it-py.svg
 [pypi-link]: https://pypi.org/project/markdown-it-py


### PR DESCRIPTION
**before**
![before](https://github.com/executablebooks/markdown-it-py/assets/23278662/489594fa-3fe3-4119-b03b-ea78a6b1c9a2)

**after**
![after](https://github.com/executablebooks/markdown-it-py/assets/23278662/6f9a4648-7133-45eb-8228-50407119d131)
