### PR TITLE
⬆️ Drop Python 3.9, test 3.13

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: install pandoc
       uses: r-lib/actions/setup-pandoc@v2

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
         pip install tox
 
     - name: Run package benchmarks
-      run: tox -e py38-bench-packages -- --benchmark-min-rounds 20 --benchmark-json bench-packages.json
+      run: tox -e py39-bench-packages -- --benchmark-min-rounds 20 --benchmark-json bench-packages.json
 
     # - name: Upload package data
     #   uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,18 +20,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - uses: pre-commit/action@v3.0.0
 
   tests:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['pypy-3.8', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['pypy-3.9', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -48,7 +49,7 @@ jobs:
       run: |
         pytest tests/ --cov=markdown_it --cov-report=xml --cov-report=term-missing
     - name: Upload to Codecov
-      if: matrix.python-version == '3.8' && github.repository == 'executablebooks/markdown-it-py'
+      if: matrix.python-version == '3.9' && github.repository == 'executablebooks/markdown-it-py'
       uses: codecov/codecov-action@v3
       with:
         name: markdown-it-py-pytests
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -86,10 +87,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Install tox
       run: |
@@ -115,10 +116,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: install flit
       run: |
         pip install flit~=3.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
         pip install tox
 
     - name: Run benchmark
-      run: tox -e py38-bench-core -- --benchmark-json bench-core.json
+      run: tox -e py39-bench-core -- --benchmark-json bench-core.json
 
     - name: Upload data
       uses: actions/upload-artifact@v3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ nitpicky = True
 nitpick_ignore_regex = [
     ("py:.*", name)
     for name in (
-        "_ItemTV",
+        ".*_ItemTV",
         ".*_NodeType",
         ".*Literal.*",
         ".*_Result",
@@ -84,7 +84,7 @@ html_css_files = ["custom.css"]
 
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/3.9", None),
     "mdit-py-plugins": ("https://mdit-py-plugins.readthedocs.io/en/latest/", None),
 }
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,7 @@ This can also be used to run benchmarking tests using [pytest-benchmark](https:/
 
 ```shell
 >> cd markdown-it-py
-tox -e py38-bench-packages -- --benchmark-min-rounds 50
+tox -e py39-bench-packages -- --benchmark-min-rounds 50
 ```
 
 For documentation build tests:

--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Match, TypeVar
+from re import Match
+from typing import TypeVar
 
 from .entities import entities
 

--- a/markdown_it/utils.py
+++ b/markdown_it/utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, MutableMapping
 from collections.abc import MutableMapping as MutableMappingABC
 from pathlib import Path
-from typing import Any, Callable, Iterable, MutableMapping, TypedDict, cast
+from typing import Any, Callable, TypedDict, cast
 
 EnvType = MutableMapping[str, Any]  # note: could use TypeAlias in python 3.10
 """Type for the environment sandbox used in parsing and rendering,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,18 +14,18 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-     "Programming Language :: Python :: 3.11",
-     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup",
 ]
 keywords = ["markdown", "lexer", "parser", "commonmark", "markdown-it"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "mdurl~=0.1",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,18 @@
 # then run `tox` or `tox -- {pytest args}`
 # run in parallel using `tox -p`
 [tox]
-envlist = py38
+envlist = py39
 
 [testenv]
 usedevelop = true
 
-[testenv:py{38,39,310,311,312}]
+[testenv:py{39,310,311,312,313}]
 extras =
     linkify
     testing
 commands = pytest {posargs:tests/}
 
-[testenv:py{38,39,310,311}-plugins]
+[testenv:py{39,310,311,312,313}-plugins]
 extras = testing
 changedir = {envtmpdir}
 allowlist_externals =
@@ -27,11 +27,11 @@ commands_pre =
 commands =
     pytest {posargs}
 
-[testenv:py{38,39,310,311,312}-bench-core]
+[testenv:py{39,310,311,312,313}-bench-core]
 extras = benchmarking
 commands = pytest benchmarking/bench_core.py {posargs}
 
-[testenv:py{38,39,310,311,312}-bench-packages]
+[testenv:py{39,310,311,312,313}-bench-packages]
 extras = benchmarking,compare
 commands = pytest benchmarking/bench_packages.py {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands = pytest benchmarking/bench_packages.py {posargs}
 
 [testenv:docs-{update,clean}]
 extras = linkify,plugins,rtd
-whitelist_externals =
+allowlist_externals =
     echo
     rm
 setenv =


### PR DESCRIPTION
Python 3.9 is end-of-life as of 2024-10-07 (https://devguide.python.org/versions/)