### PR TITLE
👌 Improve performance of "text" inline rule

### DIFF
--- a/markdown_it/rules_inline/text.py
+++ b/markdown_it/rules_inline/text.py
@@ -1,3 +1,5 @@
+import re
+
 # Skip text characters for text token, place those to pending buffer
 # and increment current pos
 from .state_inline import StateInline
@@ -34,13 +36,15 @@ _TerminatorChars = {
     "}",
     "~",
 }
+_RE_TERMINATOR_CHAR = re.compile("[" + re.escape("".join(_TerminatorChars)) + "]")
 
 
 def text(state: StateInline, silent: bool) -> bool:
     pos = state.pos
     posMax = state.posMax
-    while (pos < posMax) and state.src[pos] not in _TerminatorChars:
-        pos += 1
+
+    terminator_char = _RE_TERMINATOR_CHAR.search(state.src, pos)
+    pos = terminator_char.start() if terminator_char else posMax
 
     if pos == state.pos:
         return False

--- a/markdown_it/rules_inline/text.py
+++ b/markdown_it/rules_inline/text.py
@@ -1,3 +1,4 @@
+import functools
 import re
 
 # Skip text characters for text token, place those to pending buffer
@@ -36,14 +37,18 @@ _TerminatorChars = {
     "}",
     "~",
 }
-_RE_TERMINATOR_CHAR = re.compile("[" + re.escape("".join(_TerminatorChars)) + "]")
+
+
+@functools.cache
+def _terminator_char_regex() -> re.Pattern[str]:
+    return re.compile("[" + re.escape("".join(_TerminatorChars)) + "]")
 
 
 def text(state: StateInline, silent: bool) -> bool:
     pos = state.pos
     posMax = state.posMax
 
-    terminator_char = _RE_TERMINATOR_CHAR.search(state.src, pos)
+    terminator_char = _terminator_char_regex().search(state.src, pos)
     pos = terminator_char.start() if terminator_char else posMax
 
     if pos == state.pos:


### PR DESCRIPTION
This slightly deviates from JavaScript, but improves performance a lot.

Below the before/after results from `tox -e py312-bench-core`.

Before:
```
------------------------------------------ benchmark 'core': 1 tests ------------------------------------------
Name (time in ms)         Min      Max     Mean  StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------
test_spec             80.6105  90.4756  83.9440  4.1692  81.2779  7.7111       4;0  11.9127      12           1
---------------------------------------------------------------------------------------------------------------
```

After:
```
------------------------------------------ benchmark 'core': 1 tests ------------------------------------------
Name (time in ms)         Min      Max     Mean  StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------
test_spec             74.6913  84.1540  78.3273  3.9836  75.6576  8.0403       4;0  12.7669      13           1
---------------------------------------------------------------------------------------------------------------
```
