### PR TITLE
📚 DOCS: Fix a few old URLs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,5 +14,6 @@ python:
           - rtd
 
 sphinx:
+  configuration: docs/conf.py
   builder: html
   fail_on_warning: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 We welcome all contributions! ✨
 
-See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contributing.html) for general details, and below for guidance specific to markdown-it-py.
+See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contribute/) for general details, and below for guidance specific to markdown-it-py.
 
 Before continuing, make sure you've read:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,13 +96,13 @@ in a more convenient way.
 The right sequence is to split text to several tokens and add link tokens in between.
 The result will be: `text` + `link_open` + `text` + `link_close` + `text`.
 
-See implementations of [linkify](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/linkify.js) and [emoji](https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/replace.js) - those do text token splits.
+See implementations of [linkify](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/linkify.mjs) and [emoji](https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/replace.mjs) - those do text token splits.
 
 __Note:__ Don't try to replace text with HTML markup! That's not secure.
 
 ### Why is my inline rule not executed?
 
-The inline parser skips pieces of texts to optimize speed. It stops only on [a small set of chars](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_inline/text.js), which can be tokens. We did not made this list extensible for performance reasons too.
+The inline parser skips pieces of texts to optimize speed. It stops only on [a small set of chars](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_inline/text.mjs), which can be tokens. We did not made this list extensible for performance reasons too.
 
 If you are absolutely sure that something important is missing there - create a
 ticket and we will consider adding it as a new charcode.


### PR DESCRIPTION
Add required configuration to `.readthedocs.yaml`. See <https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/>.

Correct a few links in the documentation:
1. Correct the EBP Contributing Guide link
2. Correct links to markdown-it source code (extensions changed from `.js` to `.mjs`; this relates to https://github.com/markdown-it/markdown-it/pull/981)
