### PR TITLE
📚 DOCS: Fix typos

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ In total, a token stream is:
 - On the top level - array of paired or single "block" tokens:
   - open/close for headers, lists, blockquotes, paragraphs, ...
   - codes, fenced blocks, horizontal rules, html blocks, inlines containers
-- Each inline token have a `.children` property with a nested token stream for inline content:
+- Each inline token has a `.children` property with a nested token stream for inline content:
   - open/close for strong, em, link, code, ...
   - text, line breaks
 
@@ -81,7 +81,7 @@ Rules are functions, doing "magic" with parser `state` objects. A rule is associ
 
 Rules are managed by names via [Ruler](https://markdown-it.github.io/markdown-it/#Ruler) instances and can be  `enabled` / `disabled` from the [MarkdownIt](https://markdown-it.github.io/markdown-it/#MarkdownIt) methods.
 
-You can note, that some rules have a `validation mode` - in this mode rules do not
+Note that some rules have a `validation mode` - in this mode rules do not
 modify the token stream, and only look ahead for the end of a token. It's one
 important design principle - a token stream is "write only" on block & inline parse stages.
 
@@ -160,9 +160,9 @@ JSON/XML... You can even use it to generate AST.
 
 ## Summary
 
-This was mentioned in [Data flow](md/data-flow), but let's repeat sequence again:
+This was mentioned in [Data flow](md/data-flow), but let's repeat the sequence again:
 
-1. Blocks are parsed, and top level of token stream filled with block tokens.
+1. Blocks are parsed, and the top level of the token stream filled with block tokens.
 2. Content on inline containers is parsed, filling `.children` properties.
 3. Rendering happens.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,7 +25,7 @@ from markdown_it import MarkdownIt
 MarkdownIt("js-default").render("*user-submitted* text")
 ```
 
-Note that even with the default configuration, `markdown-it-py` prohibits some kind of links which could be used for XSS:
+Note that even with the default configuration, `markdown-it-py` prohibits some kinds of links which could be used for XSS:
 
 - `javascript:`, `vbscript:`
 - `file:`
@@ -37,8 +37,8 @@ If you find a security problem, please report it to <executablebooks@gmail.com>.
 
 Usually, plugins operate with tokenized content, and that's enough to provide safe output.
 
-But there is one non-evident case you should know - don't allow plugins to generate arbitrary element `id` and `name`.
+But there is one non-evident case you should know - don't allow plugins to generate arbitrary `id` and `name` attributes.
 If those depend on user input - always add prefixes to avoid DOM clobbering.
 See [discussion](https://github.com/markdown-it/markdown-it/issues/28) for details.
 
-So, if you decide to use plugins that add extended class syntax or autogenerating header anchors - be careful.
+So, if you decide to use plugins that add extended class syntax or autogenerate header anchors - be careful.


### PR DESCRIPTION
I've taken the liberty of correcting a few typos and adding a few definite articles ("the") to the documentation.