### PR TITLE
🔧 Add typing to Scanner

### DIFF
--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from collections import namedtuple
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from ..common.utils import isMdAsciiPunct, isPunctChar, isWhiteSpace
 from ..ruler import StateBase
@@ -36,7 +35,10 @@ class Delimiter:
     level: bool | None = None
 
 
-Scanned = namedtuple("Scanned", ["can_open", "can_close", "length"])
+class Scanned(NamedTuple):
+    can_open: bool
+    can_close: bool
+    length: int
 
 
 class StateInline(StateBase):


### PR DESCRIPTION
Changes `state_inline.Scanner` into a `typing.NamedTuple` instead of a `collections.namedtuple`. They should be functionally equivalent except that the former has typing for its members while the latter does not.

I tend to use strict type checking for my own projects so it'd be nice if Pyright didn't freak out when I try to access the result of `scanDelims` without using `typing.cast`.