### PR TITLE
Fix CJK emphasis delimiter detection in scanDelims

### DIFF
--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -148,6 +148,14 @@ class StateInline(StateBase):
         isLastWhiteSpace = isWhiteSpace(ord(lastChar))
         isNextWhiteSpace = isWhiteSpace(ord(nextChar))
 
+        # Treat CJK ideographs as punctuation for flanking delimiter checks
+        # so that emphasis works correctly in mixed CJK/ASCII contexts.
+        # e.g. 湾岸の**46%**を should render <strong>46%</strong>
+        if not isNextPunctChar and ord(nextChar) > 0x2E7F:
+            isNextPunctChar = True
+        if not isLastPunctChar and ord(lastChar) > 0x2E7F:
+            isLastPunctChar = True
+
         left_flanking = not (
             isNextWhiteSpace
             or (isNextPunctChar and not (isLastWhiteSpace or isLastPunctChar))


### PR DESCRIPTION
## Summary
Fix emphasis delimiter detection for mixed CJK/ASCII text.

In CommonMark's `scanDelims`, when an emphasis closing marker `**` is preceded by ASCII punctuation (e.g. `%`) and followed by a CJK character, `right_flanking` evaluates to `False` — causing bold to silently fail.

Example: `湾岸の**46%**を` renders as plain text instead of `<strong>46%</strong>`.

## Root Cause
CJK characters (e.g. `を`, `の`, `は`) are not classified as whitespace or punctuation by the spec. When `lastChar='%'` (punctuation) and `nextChar='を'` (neither whitespace nor punctuation):

`right_flanking = not (isLastPunctChar and not (isNextWhiteSpace or isNextPunctChar))`

evaluates to `False`, so the closing `**` is rejected.

## Fix
Treat characters above U+2E7F as punctuation for flanking delimiter checks (6 lines added to `scanDelims` in `state_inline.py`). This covers CJK Unified Ideographs, Hiragana, Katakana, Hangul, and other East Asian scripts.

## Test Cases
```
from markdown_it import MarkdownIt
md = MarkdownIt("commonmark")

assert "<strong>" in md.render("湾岸の**46%**を供給")
assert "<strong>" in md.render("の**20〜25%**が通過する")
assert "<strong>" in md.render("日本語の**太字**テスト")
assert "<strong>" in md.render("**全部太字**")
assert "<strong>" in md.render("English **bold** test")
```
All pass. Existing English-only behavior is unchanged.

## Note
The same bug likely exists in the JavaScript version of markdown-it.