### PR TITLE
🐛 Drop empty text tokens left by emphasis postprocessor

### DIFF
--- a/markdown_it/rules_inline/fragments_join.py
+++ b/markdown_it/rules_inline/fragments_join.py
@@ -45,6 +45,19 @@ def fragments_join(state: StateInline) -> None:
             last += 1
             continue
 
+        if state.tokens[curr].type == "text" and not state.tokens[curr].content:
+            # Drop standalone empty text tokens. The emphasis postprocessor
+            # only converts the *inner* marker of a `**` pair into a
+            # strong_open/close tag and blanks the *outer* marker's content
+            # while leaving it as a text token (see emphasis.py `_postProcess`
+            # `if isStrong:` block). The outer-opening empty has an adjacent
+            # text on its left and gets folded by the merge branch above; the
+            # outer-closing empty often sits between two tags (e.g.
+            # `_li**ne**_` puts it between `strong_close` and `em_close`),
+            # has no text neighbor, and would otherwise survive.
+            curr += 1
+            continue
+
         if curr != last:
             state.tokens[last] = state.tokens[curr]
         last += 1

--- a/tests/test_port/test_misc.py
+++ b/tests/test_port/test_misc.py
@@ -42,3 +42,17 @@ def test_ordered_list_info():
     assert tokens[2].markup == "."
     assert tokens[3].info == "199"
     assert tokens[3].markup == "."
+
+
+def test_no_empty_text_tokens_after_nested_emphasis():
+    # Regression test for #374: when nested emphasis delimiters close at the
+    # same position (e.g. `_li**ne**_`), the closing `_` delimiter used to
+    # leave behind an empty `text` token between `strong_close` and `em_close`.
+    md = MarkdownIt("gfm-like").disable(["linkify"])
+    for source in ("new _li**ne**_", "new _l**i**ne_", "new _**line**_"):
+        tokens = md.parse(source)
+        [inline] = [t for t in tokens if t.type == "inline"]
+        empties = [
+            c for c in (inline.children or []) if c.type == "text" and not c.content
+        ]
+        assert empties == [], f"empty text tokens left in stream for {source!r}"

--- a/tests/test_tree/test_pretty.xml
+++ b/tests/test_tree/test_pretty.xml
@@ -19,7 +19,6 @@
           <strong>
             <text>
               list
-          <text>
   <blockquote>
     <paragraph>
       <inline>


### PR DESCRIPTION
Closes #374.

`emphasis._postProcess` only converts the *inner* marker of a `**` pair into the `strong_open`/`strong_close` tag and blanks the *outer* marker's content while leaving it as a `text` token. `fragments_join`'s adjacent-text merge folds the outer-opening residue away, but the outer-closing residue often sits between two tag tokens (e.g. between `strong_close` and `em_close` in `_li**ne**_`) and survives.

Added a branch to `fragments_join` that drops a standalone empty-content `text` token. `tests/test_tree/test_pretty.xml` had frozen this exact bug as expected output since 2021 (09edd66) — the one removed line is that captured residue.