### PR TITLE
🐛 FIX: html_block: blank lines inside containers prematurely terminate non-blank-line-terminator sequences

### DIFF
--- a/markdown_it/rules_block/html_block.py
+++ b/markdown_it/rules_block/html_block.py
@@ -68,7 +68,7 @@ def html_block(state: StateBlock, startLine: int, endLine: int, silent: bool) ->
     # Let's roll down till block end.
     if not html_seq[1].search(lineText):
         while nextLine < endLine:
-            if state.sCount[nextLine] < state.blkIndent:
+            if state.sCount[nextLine] < state.blkIndent and not state.isEmpty(nextLine):
                 break
 
             pos = state.bMarks[nextLine] + state.tShift[nextLine]

--- a/tests/test_port/fixtures/commonmark_extras.md
+++ b/tests/test_port/fixtures/commonmark_extras.md
@@ -749,3 +749,27 @@ Issue #204. Combination of blockquotes, list and newlines causes an IndexError
 </li>
 </ul>
 .
+
+Issue #377. HTML comment block inside list item should not end at blank line
+.
+1. item
+
+    <!--
+    comment with
+
+    blank line inside
+    -->
+    paragraph
+.
+<ol>
+<li>
+<p>item</p>
+ <!--
+ comment with
+
+ blank line inside
+ -->
+<p>paragraph</p>
+</li>
+</ol>
+.


### PR DESCRIPTION
## Problem

HTML blocks started with `<!--`, `<?`, `<!A`, `<![CDATA[`, or `<script>`/`<pre>`/`<style>`/`<textarea>` (CommonMark types 1–5) have **specific** end conditions (`-->`, `?>`, `>`, `]]>`, closing tags). Per [CommonMark spec §4.6](https://spec.commonmark.org/0.31.2/#html-blocks), these blocks continue until the matching end tag is found, or the last line of the document/container — **blank lines inside them do not terminate them**.

When such a block appeared inside a container (e.g. a list item), a blank line within the comment caused early termination. The scan loop in `html_block` checks `state.sCount[nextLine] < state.blkIndent` to detect container boundaries, but blank lines always have `sCount = 0`, so any positive `blkIndent` (set by the list rule) incorrectly fired the guard.

**Reproduction** (from #377):

```python
from markdown_it import MarkdownIt
md = MarkdownIt()
text = '''1. item

    <!--
    The following code block specifies the full path.

    [1]: <https://example.com>
    -->
    paragraph
'''
print(md.render(text))
```

Before this fix, `-->` was escaped as `--&gt;` inside a paragraph (comment prematurely closed at the blank line).

## Fix

One-character addition: skip the `sCount < blkIndent` guard when the line is blank (`state.isEmpty(nextLine)`). Blank lines in sequences 6–7 (end condition `^$`) still terminate correctly because an empty `lineText` matches `^$` through the existing end-condition check.

## Test

New fixture in `commonmark_extras.md` covering the exact case from #377.

This pull request was prepared with the assistance of AI, under my direction and review.