### PR TITLE
🔧 Fix typo in newline.py module docstring

### DIFF
--- a/markdown_it/rules_inline/newline.py
+++ b/markdown_it/rules_inline/newline.py
@@ -1,4 +1,4 @@
-"""Proceess '\n'."""
+"""Process '\n'."""
 
 from ..common.utils import charStrAt, isStrSpace
 from .state_inline import StateInline


### PR DESCRIPTION
Fix a double-letter typo in the module docstring of `markdown_it/rules_inline/newline.py`.

`Proceess` → `Process`

Found with codespell.