### PR TITLE
📚 fix typo and use HTTPS for CommonMark spec links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 > Markdown parser done right.
 
-- {fa}`check,text-success mr-1` Follows the __[CommonMark spec](http://spec.commonmark.org/)__ for baseline parsing
+- {fa}`check,text-success mr-1` Follows the __[CommonMark spec](https://spec.commonmark.org/)__ for baseline parsing
 - {fa}`check,text-success mr-1` Configurable syntax: you can add new rules and even replace existing ones.
 - {fa}`check,text-success mr-1` Pluggable: Adds syntax extensions to extend the parser (see the [plugin list](md/plugins))
 - {fa}`check,text-success mr-1` High speed (see our [benchmarking tests](md/performance))

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -25,4 +25,4 @@ As you can see, `markdown-it-py` doesn't pay with speed for it's flexibility.
 [^1]: `markdown-it-pyrs` is a Rust implementation of `markdown-it-py`'s parser, in beta development, check it out at: <https://github.com/chrisjsewell/markdown-it-pyrs>
 [^2]: `mistune` is not CommonMark compliant, which is what allows for its
 faster parsing, at the expense of issues, for example, with nested inline parsing.
-See [mistletoes's explanation](https://github.com/miyuchina/mistletoe/blob/master/performance.md) for further details.
+See [mistletoe's explanation](https://github.com/miyuchina/mistletoe/blob/master/performance.md) for further details.

--- a/docs/using.md
+++ b/docs/using.md
@@ -52,7 +52,7 @@ dictating the syntax rules and additional options for the parser and renderer.
 You can define this configuration *via* directly supplying a dictionary or a preset name:
 
 - `zero`: This configures the minimum components to parse text (i.e. just paragraphs and text)
-- `commonmark` (default): This configures the parser to strictly comply with the [CommonMark specification](http://spec.commonmark.org/).
+- `commonmark` (default): This configures the parser to strictly comply with the [CommonMark specification](https://spec.commonmark.org/).
 - `js-default`: This is the default in the JavaScript version.
   Compared to `commonmark`, it disables HTML parsing and enables the table and strikethrough components.
 - `gfm-like`: This configures the parser to approximately comply with the [GitHub Flavored Markdown specification](https://github.github.com/gfm/).


### PR DESCRIPTION
## Summary

A few small documentation fixes across `docs/`:

- **`docs/performance.md`**: fix a typo in footnote `[^2]` — `mistletoes's` → `mistletoe's`. The project being referenced is named **mistletoe** (singular), so the possessive was incorrectly formed with an extra `s`. (The unrelated `it's` → `its` fix on the same file is already handled in #402, so it is intentionally left untouched here to avoid duplicating that change.)
- **`docs/index.md`** and **`docs/using.md`**: update the CommonMark specification link from `http://spec.commonmark.org/` to `https://spec.commonmark.org/`. The site serves over HTTPS and this keeps the docs consistent with the HTTPS links already used elsewhere in the project (e.g. the GitHub Flavored Markdown link in `using.md`).

These are documentation-only changes; no code or tests are affected.

## Notes

- There is no corresponding open issue for these; they are minor docs/typo corrections spotted while reading the documentation. Happy to open an issue if the maintainers prefer one linked.
- I checked that no existing open PR already covers the `mistletoe's` typo or these `http` → `https` spec-link updates (#402 only touches the `it's`/`its` line).

## AI usage disclosure

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.
