### PR TITLE
🐛 FIX: render hardbreak and inline HTML in image alt text

### DIFF
--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -202,7 +202,9 @@ class RendererHTML(RendererProtocol):
             elif token.type == "image":
                 if token.children:
                     result += self.renderInlineAsText(token.children, options, env)
-            elif token.type == "softbreak":
+            elif token.type in ("html_inline", "html_block"):
+                result += token.content
+            elif token.type in ("softbreak", "hardbreak"):
                 result += "\n"
 
         return result

--- a/tests/test_port/fixtures/commonmark_extras.md
+++ b/tests/test_port/fixtures/commonmark_extras.md
@@ -749,3 +749,19 @@ Issue #204. Combination of blockquotes, list and newlines causes an IndexError
 </li>
 </ul>
 .
+
+Hardbreak in image description
+.
+![foo\
+bar](/url)
+.
+<p><img src="/url" alt="foo
+bar" /></p>
+.
+
+Inline HTML in image description
+.
+![a<b>c](/url)
+.
+<p><img src="/url" alt="a&lt;b&gt;c" /></p>
+.


### PR DESCRIPTION
`RendererHTML.renderInlineAsText` builds the `alt` attribute for images by walking the inline token stream, but it only handles `text`, `image` and `softbreak` tokens. `hardbreak`, `html_inline` and `html_block` are silently dropped, so a hard line break or inline HTML inside an image description disappears from the alt text.

```python
from markdown_it import MarkdownIt
md = MarkdownIt("commonmark")

md.render("![foo\\\nbar](/url)")   # hard break (backslash)
# now:  <p><img src="/url" alt="foobar" /></p>
# want: <p><img src="/url" alt="foo\nbar" /></p>   (soft break already does this)

md.render("![a<b>c](/url)")        # inline HTML
# now:  <p><img src="/url" alt="ac" /></p>
# want: <p><img src="/url" alt="a&lt;b&gt;c" /></p>
```

### Why this is the intended behaviour

Two independent references, both pointing the same way:

- **JS parity.** This project is a port of `markdown-it` and the changelog pins the parser to `markdown-it v14.1.0`. Upstream `renderInlineAsText` at that version handles `text`, `image`, `html_inline`, `html_block`, `softbreak` **and** `hardbreak`. The Python port is behind its own declared target for the last three.
- **Internal consistency.** `softbreak` and `hardbreak` are treated as an identical pair everywhere else in the codebase; #157 previously added the `softbreak` branch to this very function but stopped there. This change is the sibling of that fix.

HTML content in `alt` is escaped downstream by `renderAttrs` → `escapeHtml` (so `<b>` becomes `&lt;b&gt;`), matching the JS behaviour — no markup reaches the attribute unescaped.

### The fix

Two grouped branches added to `renderInlineAsText`, making it a 1:1 match of the upstream reference:

```python
elif token.type in ("html_inline", "html_block"):
    result += token.content
elif token.type in ("softbreak", "hardbreak"):
    result += "\n"
```

### Verification

- Added two cases to `tests/test_port/fixtures/commonmark_extras.md` (hard break and inline HTML in an image description), mirroring the existing #157 soft-break fixture. Both **fail without the change** and **pass with it**.
- `renderInlineAsText` has a single production caller (the `image` renderer), and the soft-break / plain-text paths are unchanged (verified as controls).
- Full test suite: **983 passed**. `pre-commit` ruff, ruff-format and mypy (strict) all clean.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
