### PR TITLE
👌 Fix quadratic inline tokenization on runs of special characters

### DIFF
--- a/markdown_it/common/html_re.py
+++ b/markdown_it/common/html_re.py
@@ -21,7 +21,9 @@ declaration = "<![A-Za-z][^>]*>"
 cdata = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>"
 
 HTML_TAG_RE = re.compile(
-    "^(?:"
+    # No leading `^`: this is applied with `.match(src, pos)`, which anchors at
+    # `pos` without slicing `src[pos:]` (O(len) per call, quadratic over a run).
+    "(?:"
     + open_tag
     + "|"
     + close_tag

--- a/markdown_it/parser_inline.py
+++ b/markdown_it/parser_inline.py
@@ -197,7 +197,7 @@ class ParserInline:
                     break
                 continue
 
-            state.pending += state.src[state.pos]
+            state.append_pending(state.src[state.pos])
             state.pos += 1
 
         if state.pending:

--- a/markdown_it/rules_inline/backticks.py
+++ b/markdown_it/rules_inline/backticks.py
@@ -25,7 +25,7 @@ def backtick(state: StateInline, silent: bool) -> bool:
 
     if state.backticksScanned and state.backticks.get(openerLength, 0) <= start:
         if not silent:
-            state.pending += marker
+            state.append_pending(marker)
         state.pos += openerLength
         return True
 
@@ -67,6 +67,6 @@ def backtick(state: StateInline, silent: bool) -> bool:
     state.backticksScanned = True
 
     if not silent:
-        state.pending += marker
+        state.append_pending(marker)
     state.pos += openerLength
     return True

--- a/markdown_it/rules_inline/entity.py
+++ b/markdown_it/rules_inline/entity.py
@@ -5,8 +5,12 @@ from ..common.entities import entities
 from ..common.utils import fromCodePoint, isValidEntityCode
 from .state_inline import StateInline
 
-DIGITAL_RE = re.compile(r"^&#((?:x[a-f0-9]{1,6}|[0-9]{1,7}));", re.IGNORECASE)
-NAMED_RE = re.compile(r"^&([a-z][a-z0-9]{1,31});", re.IGNORECASE)
+# NB: these are matched at a given position with `.match(src, pos)` (which
+# anchors there), so no leading `^` is needed. Anchoring this way avoids slicing
+# `src[pos:]` on every `&`, which is O(len) per call and makes long runs of
+# ampersands quadratic.
+DIGITAL_RE = re.compile(r"&#((?:x[a-f0-9]{1,6}|[0-9]{1,7}));", re.IGNORECASE)
+NAMED_RE = re.compile(r"&([a-z][a-z0-9]{1,31});", re.IGNORECASE)
 
 
 def entity(state: StateInline, silent: bool) -> bool:
@@ -20,7 +24,7 @@ def entity(state: StateInline, silent: bool) -> bool:
         return False
 
     if state.src[pos + 1] == "#":
-        if match := DIGITAL_RE.search(state.src[pos:]):
+        if match := DIGITAL_RE.match(state.src, pos):
             if not silent:
                 match1 = match.group(1)
                 code = (
@@ -40,7 +44,7 @@ def entity(state: StateInline, silent: bool) -> bool:
             return True
 
     else:
-        if (match := NAMED_RE.search(state.src[pos:])) and match.group(1) in entities:
+        if (match := NAMED_RE.match(state.src, pos)) and match.group(1) in entities:
             if not silent:
                 token = state.push("text_special", "", 0)
                 token.content = entities[match.group(1)]

--- a/markdown_it/rules_inline/html_inline.py
+++ b/markdown_it/rules_inline/html_inline.py
@@ -26,7 +26,7 @@ def html_inline(state: StateInline, silent: bool) -> bool:
     if ch not in ("!", "?", "/") and not isLetter(ord(ch)):  # /* / */
         return False
 
-    match = HTML_TAG_RE.search(state.src[pos:])
+    match = HTML_TAG_RE.match(state.src, pos)
     if not match:
         return False
 

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -54,7 +54,15 @@ class StateInline(StateBase):
         self.pos = 0
         self.posMax = len(self.src)
         self.level = 0
-        self.pending = ""
+        # `pending` accumulates literal text that has not yet been flushed to a
+        # token. It is exposed as a `str` via the property below, but is built
+        # up through a list buffer so that appending a character at a time (the
+        # inline tokenizer's fallback path) stays O(1) instead of O(n) per
+        # append -- the latter makes long runs of non-markup characters (e.g.
+        # `&&&&...`) quadratic, since `str += ch` on an attribute cannot reuse
+        # the string in place.
+        self._pending = ""
+        self._pending_buffer: list[str] = []
         self.pendingLevel = 0
 
         # Stores { start: end } pairs. Useful for backtrack
@@ -80,6 +88,27 @@ class StateInline(StateBase):
             f"{self.__class__.__name__}"
             f"(pos=[{self.pos} of {self.posMax}], token={len(self.tokens)})"
         )
+
+    @property
+    def pending(self) -> str:
+        """The literal text accumulated but not yet flushed to a token."""
+        if self._pending_buffer:
+            self._pending += "".join(self._pending_buffer)
+            self._pending_buffer.clear()
+        return self._pending
+
+    @pending.setter
+    def pending(self, value: str) -> None:
+        self._pending = value
+        self._pending_buffer.clear()
+
+    def append_pending(self, text: str) -> None:
+        """Append literal text to `pending` in amortised O(1) time.
+
+        Prefer this over ``state.pending += text`` on hot paths: it buffers the
+        fragment instead of rebuilding the whole ``pending`` string each call.
+        """
+        self._pending_buffer.append(text)
 
     def pushPending(self) -> Token:
         token = Token("text", "", 0)

--- a/markdown_it/rules_inline/text.py
+++ b/markdown_it/rules_inline/text.py
@@ -16,7 +16,7 @@ def text(state: StateInline, silent: bool) -> bool:
         return False
 
     if not silent:
-        state.pending += state.src[state.pos : pos]
+        state.append_pending(state.src[state.pos : pos])
 
     state.pos = pos
 

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -365,3 +365,37 @@ def test_text_join_merges_adjacent_text_special_tokens():
     assert len(children_on) == 1
     assert children_on[0].type == "text"
     assert children_on[0].content == "***"
+
+
+def test_long_special_char_runs_stay_linear():
+    """Runs of characters that begin an inline rule but do not form a construct
+    must tokenise in linear time.
+
+    Bare ``&``/``<``, incomplete entities, etc. were previously O(n^2): the
+    inline tokenizer appended to the ``pending`` string one character at a time
+    (``str += ch`` on an attribute cannot reuse the buffer in place), and the
+    ``entity``/``html_inline`` rules sliced ``src[pos:]`` on every character.
+    The headline case below would exceed the global 10s test timeout if that
+    quadratic behaviour regressed.
+    """
+    md = MarkdownIt()
+
+    # Headline: half a million bare ampersands. Linear renders in well under a
+    # second; the previous O(n^2) behaviour would blow the 10s timeout.
+    big = 500_000
+    assert md.renderInline("&" * big) == "&amp;" * big
+
+    # Correctness across the related constructs (kept small).
+    for src, expected in [
+        ("&" * 1000, "&amp;" * 1000),
+        ("&amp;" * 1000, "&amp;" * 1000),
+        ("&#" * 1000, "&amp;#" * 1000),
+        ("&am" * 1000, "&amp;am" * 1000),
+        ("<" * 1000, "&lt;" * 1000),
+    ]:
+        assert md.renderInline(src) == expected
+
+    # The ``html_inline`` slice was only reachable with ``html=True``; ``<a<a…``
+    # are not valid tags, so they render escaped.
+    md_html = MarkdownIt("commonmark", {"html": True})
+    assert md_html.renderInline("<a" * 250_000) == "&lt;a" * 250_000


### PR DESCRIPTION
## Summary

Long runs of characters that begin an inline rule but do not form a construct — bare `&` / `<`, incomplete entities like `&am&am…`, etc. — were tokenised in **O(n²)** time. A single such character is fine; it is the *count* that blows up. For example, `md.render("&" * 128_000)` took over a second and grew quadratically.

This is the same class as the previously fixed #367 and #389.

## Root causes

Two independent quadratic factors, both hit once per character in these runs:

1. **`state.pending` accumulation.** The inline tokenizer's fallback path does `state.pending += state.src[state.pos]` one character at a time. Because `pending` is an attribute, `str += ch` cannot use CPython's in-place concatenation optimisation (the attribute keeps a second reference), so each append rebuilds the whole string — O(len) per character.
2. **`src[pos:]` slicing in `entity` / `html_inline`.** These rules matched `^`-anchored regexes against `state.src[pos:]`, copying the remaining source on every `&` / `<`.

In JavaScript `markdown-it` neither is quadratic (rope-backed string concat, and the equivalent regexes are applied with a sticky/lastIndex match), so this is Python-port-specific.

## Fix

- `StateInline.pending` now accumulates through a lazily-materialised list buffer (`append_pending`), giving amortised O(1) appends. It still presents as a plain `str` to every reader (the getter joins the buffer on demand and caches).
- `entity` and `html_inline` anchor their regexes with `.match(state.src, pos)` instead of slicing (the leading `^` is dropped, since `.match` already anchors at `pos`). `HTML_TAG_RE` is only used by `html_inline`, so this is contained.

Rendering is now linear in all these cases (measured slope ≈ 1.0, including the `html=True` `html_inline` path); `"&" * 500_000` drops from seconds to well under one. **Output is unchanged** — the full test suite passes.

## Tests

Added `test_long_special_char_runs_stay_linear` in `tests/test_api/test_main.py`: it asserts correct rendering for the affected constructs and renders a large input whose previous O(n²) behaviour would exceed the global 10s test timeout. Full `pytest tests/` passes (982). `ruff check` / `ruff format` (0.15.12) and `mypy` (1.20.2, strict) are clean.

---

Disclosure: this fix was developed with AI assistance; I reviewed it and stand behind it.
