### PR TITLE
🐛 FIX: IndexError in html_block/heading terminator rules at EOF

### DIFF
--- a/markdown_it/rules_block/heading.py
+++ b/markdown_it/rules_block/heading.py
@@ -19,7 +19,10 @@ def heading(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bo
     if state.is_code_block(startLine):
         return False
 
-    ch: str | None = state.src[pos]
+    try:
+        ch: str | None = state.src[pos]
+    except IndexError:
+        return False
 
     if ch != "#" or pos >= maximum:
         return False

--- a/markdown_it/rules_block/html_block.py
+++ b/markdown_it/rules_block/html_block.py
@@ -44,7 +44,10 @@ def html_block(state: StateBlock, startLine: int, endLine: int, silent: bool) ->
     if not state.md.options.get("html", None):
         return False
 
-    if state.src[pos] != "<":
+    try:
+        if state.src[pos] != "<":
+            return False
+    except IndexError:
         return False
 
     lineText = state.src[pos:maximum]

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -23,3 +23,23 @@ def test_fuzzing(raw_input, expected):
     md = MarkdownIt()
     md.parse(raw_input)
     assert md.render(raw_input) == expected
+
+
+# Input that ends on a blockquote marker while a table is open inside the quote
+# used to raise ``IndexError: string index out of range`` from the terminator
+# rules ``html_block`` and ``heading`` (gh-issue 415). ``table`` must be enabled
+# for the terminator rules to run on that line.
+GH_415_INPUT = "> | a | b |\n> |---|---|\n>"
+
+
+def test_gh_415_table_in_blockquote_at_eof_html_block() -> None:
+    # html_block runs first, so with html enabled it is the rule that used to raise
+    md = MarkdownIt().enable("table")
+    md.render(GH_415_INPUT)  # must not raise IndexError
+
+
+def test_gh_415_table_in_blockquote_at_eof_heading() -> None:
+    # with html disabled, html_block bails at its options check and heading is
+    # the terminator rule that used to raise
+    md = MarkdownIt("commonmark", {"html": False}).enable("table")
+    md.render(GH_415_INPUT)  # must not raise IndexError


### PR DESCRIPTION
## Summary
Fixes #415. Input that ends on a blockquote marker while a table is open inside that quote raises `IndexError: string index out of range`:

```python
from markdown_it import MarkdownIt

# html_block.py — raises IndexError
MarkdownIt().enable("table").parse("> | a | b |\n> |---|---|\n>")

# heading.py — same input, raises once html_block is out of the way
MarkdownIt("commonmark", {"html": False}).enable("table").parse("> | a | b |\n> |---|---|\n>")
```

## Root cause
With `table` enabled, `html_block` and `heading` run as **terminator rules** on the empty final line that a trailing `>` produces. There, `pos = state.bMarks[startLine] + state.tShift[startLine]` equals `len(state.src)`, and both rules index `state.src[pos]` without guarding that boundary:

- `html_block.py`: `if state.src[pos] != "<":`
- `heading.py`: `ch = state.src[pos]` — its `pos >= maximum` check is on the *next* line, after the index

In markdown-it (JS) the equivalent `state.src.charCodeAt(pos)` returns `NaN` out of range instead of raising — the port hazard tracked in #190.

## Fix
Sibling terminator rules already defend against exactly this — `hr.py` and `blockquote.py` wrap the same index access in `try: ... except IndexError: return False` (added for #185 / #204). `html_block.py` and `heading.py` were missed. This applies the same established guard to both.

`html_block` runs before `heading`, so it shadows it (disabling `html` moves the traceback to `heading` rather than fixing it) — hence both rules need the guard, and there is a regression test for each path.

## Tests
Added two regression tests in `tests/test_fuzzer.py` (the existing home for crash-regression cases), one per crash path — asserting the input renders without raising.

## Note on local verification
I verified the guard logic in isolation (the old expression raises `IndexError` when `pos == len(src)`; the guarded version returns `False`, i.e. the rule declines, with identical behavior for in-range characters — matching how `hr.py`/`blockquote.py` already behave). I was not able to run the full pytest suite locally (my environment's Python predates this package's minimum), so I'd appreciate CI confirming the two new tests pass and that the rendered output for that input is sensible. Happy to adjust the tests to assert exact rendered HTML if you'd prefer that over "does not raise".
