### PR TITLE
🐛 FIX: keep the hard line break after a literal backslash

### DIFF
--- a/markdown_it/rules_inline/escape.py
+++ b/markdown_it/rules_inline/escape.py
@@ -36,6 +36,17 @@ def escape(state: StateInline, silent: bool) -> bool:
         state.pos = pos
         return True
 
+    # '\' before a space is a literal backslash. Don't consume the space, so a
+    # trailing two-space hard line break is still detected by the newline rule.
+    if ch1 == " ":
+        if not silent:
+            token = state.push("text_special", "", 0)
+            token.content = "\\"
+            token.markup = "\\"
+            token.info = "escape"
+        state.pos = pos
+        return True
+
     escapedStr = state.src[pos]
 
     if ch1_ord >= 0xD800 and ch1_ord <= 0xDBFF and pos + 1 < maximum:

--- a/tests/test_port/test_misc.py
+++ b/tests/test_port/test_misc.py
@@ -42,3 +42,11 @@ def test_ordered_list_info():
     assert tokens[2].markup == "."
     assert tokens[3].info == "199"
     assert tokens[3].markup == "."
+
+
+def test_backslash_before_two_space_hardbreak():
+    # A literal backslash directly before a two-space hard line break must not
+    # consume a space, otherwise only one space is left and the newline rule
+    # produces a soft break instead of a hard break.
+    md = MarkdownIt("commonmark")
+    assert md.render("foo\\  \nbar") == "<p>foo\\<br />\nbar</p>\n"


### PR DESCRIPTION
markdown-it-py renders a literal backslash immediately before a two-space hard line break as a soft break with a stray space, rather than a hard break:

```python
from markdown_it import MarkdownIt

MarkdownIt("commonmark").render("foo\\  \nbar")
# markdown-it-py: '<p>foo\\ \nbar</p>\n'
# markdown-it:    '<p>foo\\<br />\nbar</p>\n'
```

markdown-it's `escape` rule has a dedicated case for this: when a `\` is followed by a space it emits just the backslash and leaves the space unconsumed, so the trailing two-space hard break is still detected by the newline rule (its `escape.mjs` even carries a comment to that effect). This port jumped straight to the generic escape branch, which consumed the space and left only one space before the newline, so the hard break was downgraded to a soft break.

This ports the missing space case so the output matches markdown-it. I added a regression test in `test_misc.py`, and the `test_cmark_spec` and `test_port` suites still pass.
