### PR TITLE
fix: include tests/ (and tox.ini) in the flit sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,9 +81,12 @@ markdown-it = "markdown_it.cli.parse:main"
 name = "markdown_it"
 
 [tool.flit.sdist]
+include = [
+    "tests/",
+    "tox.ini",
+]
 exclude = [
     "docs/",
-    "tests/",
     "benchmarking/"
 ]
 

--- a/tests/test_packaging/test_sdist_includes_tests.py
+++ b/tests/test_packaging/test_sdist_includes_tests.py
@@ -1,0 +1,25 @@
+"""Regression for https://github.com/executablebooks/markdown-it-py/issues/261."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_flit_sdist_includes_tests_directory() -> None:
+    """sdist must ship tests/ (and tox.ini) so downstream packagers can run them."""
+    text = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    # Locate the flit sdist table without requiring tomllib (3.10 CI).
+    start = text.index("[tool.flit.sdist]")
+    rest = text[start + len("[tool.flit.sdist]") :]
+    end = rest.find("\n[")
+    block = rest if end < 0 else rest[:end]
+    assert 'include = [' in block
+    assert '"tests/"' in block
+    assert '"tox.ini"' in block
+    # Still exclude heavy non-test trees.
+    assert '"docs/"' in block
+    assert '"benchmarking/"' in block
+    # Must not exclude tests anymore.
+    assert '"tests/"' not in block.split("exclude", 1)[-1]

--- a/tests/test_packaging/test_sdist_includes_tests.py
+++ b/tests/test_packaging/test_sdist_includes_tests.py
@@ -15,7 +15,7 @@ def test_flit_sdist_includes_tests_directory() -> None:
     rest = text[start + len("[tool.flit.sdist]") :]
     end = rest.find("\n[")
     block = rest if end < 0 else rest[:end]
-    assert 'include = [' in block
+    assert "include = [" in block
     assert '"tests/"' in block
     assert '"tox.ini"' in block
     # Still exclude heavy non-test trees.


### PR DESCRIPTION
## Summary
- Fixes #261: PyPI sdists shipped `tox.ini` but omitted `tests/`, so distro packagers could not run the project's tests from the source tarball.
- `flit_core`'s default file set does not pull in VCS extras the way full `flit` does, and `tests/` was also listed under `[tool.flit.sdist] exclude`. Explicitly `include` `tests/` and `tox.ini`; keep `docs/` and `benchmarking/` excluded.
- Adds a small regression test that locks the flit sdist include/exclude table.

## Test plan
- [x] `python -m build --sdist` and confirm the tarball contains `tests/` (44 files) and `tox.ini`
- [x] `pytest tests/test_packaging/test_sdist_includes_tests.py`