### PR TITLE
👌 Fix quadratic inline tokenization on runs of special characters

### DIFF
--- a/markdown_it/common/html_re.py
+++ b/markdown_it/common/html_re.py
@@ -21,7 +21,9 @@ declaration = "<![A-Za-z][^>]*>"
 cdata = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>"
 
 HTML_TAG_RE = re.compile(
-    "^(?:"
+    # No leading `^`: applied via `.match(src, pos)`, which anchors at `pos`
+    # without slicing `src[pos:]` (an O(len) copy per call, quadratic over a run).
+    "(?:"
     + open_tag
     + "|"
     + close_tag

--- a/markdown_it/parser_inline.py
+++ b/markdown_it/parser_inline.py
@@ -197,7 +197,7 @@ class ParserInline:
                     break
                 continue
 
-            state.pending += state.src[state.pos]
+            state.append_pending(state.src[state.pos])
             state.pos += 1
 
         if state.pending:

--- a/markdown_it/rules_inline/backticks.py
+++ b/markdown_it/rules_inline/backticks.py
@@ -25,7 +25,7 @@ def backtick(state: StateInline, silent: bool) -> bool:
 
     if state.backticksScanned and state.backticks.get(openerLength, 0) <= start:
         if not silent:
-            state.pending += marker
+            state.append_pending(marker)
         state.pos += openerLength
         return True
 
@@ -67,6 +67,6 @@ def backtick(state: StateInline, silent: bool) -> bool:
     state.backticksScanned = True
 
     if not silent:
-        state.pending += marker
+        state.append_pending(marker)
     state.pos += openerLength
     return True

--- a/markdown_it/rules_inline/entity.py
+++ b/markdown_it/rules_inline/entity.py
@@ -5,8 +5,11 @@ from ..common.entities import entities
 from ..common.utils import fromCodePoint, isValidEntityCode
 from .state_inline import StateInline
 
-DIGITAL_RE = re.compile(r"^&#((?:x[a-f0-9]{1,6}|[0-9]{1,7}));", re.IGNORECASE)
-NAMED_RE = re.compile(r"^&([a-z][a-z0-9]{1,31});", re.IGNORECASE)
+# NB: no leading `^` -- these are applied via `.match(src, pos)`, which already
+# anchors at `pos`.  Anchoring this way avoids building `src[pos:]` on every
+# `&`, which is an O(len) copy per call and makes long runs quadratic.
+DIGITAL_RE = re.compile(r"&#((?:x[a-f0-9]{1,6}|[0-9]{1,7}));", re.IGNORECASE)
+NAMED_RE = re.compile(r"&([a-z][a-z0-9]{1,31});", re.IGNORECASE)
 
 
 def entity(state: StateInline, silent: bool) -> bool:
@@ -20,7 +23,7 @@ def entity(state: StateInline, silent: bool) -> bool:
         return False
 
     if state.src[pos + 1] == "#":
-        if match := DIGITAL_RE.search(state.src[pos:]):
+        if match := DIGITAL_RE.match(state.src, pos):
             if not silent:
                 match1 = match.group(1)
                 code = (
@@ -40,7 +43,7 @@ def entity(state: StateInline, silent: bool) -> bool:
             return True
 
     else:
-        if (match := NAMED_RE.search(state.src[pos:])) and match.group(1) in entities:
+        if (match := NAMED_RE.match(state.src, pos)) and match.group(1) in entities:
             if not silent:
                 token = state.push("text_special", "", 0)
                 token.content = entities[match.group(1)]

--- a/markdown_it/rules_inline/html_inline.py
+++ b/markdown_it/rules_inline/html_inline.py
@@ -26,7 +26,7 @@ def html_inline(state: StateInline, silent: bool) -> bool:
     if ch not in ("!", "?", "/") and not isLetter(ord(ch)):  # /* / */
         return False
 
-    match = HTML_TAG_RE.search(state.src[pos:])
+    match = HTML_TAG_RE.match(state.src, pos)
     if not match:
         return False
 

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -54,7 +54,16 @@ class StateInline(StateBase):
         self.pos = 0
         self.posMax = len(self.src)
         self.level = 0
-        self.pending = ""
+        # `pending` holds literal text not yet flushed to a token.  It is
+        # exposed as a plain `str` (see the property below), but is accumulated
+        # through a list buffer so that appending one character at a time -- the
+        # inline tokenizer's fallback path -- stays amortised O(1).  Appending
+        # to a `str` *attribute* cannot use CPython's in-place concatenation
+        # optimisation (the attribute holds a second reference), so each `+=`
+        # copies the whole string, making long runs of non-markup characters
+        # quadratic.
+        self._pending = ""
+        self._pending_buffer: list[str] = []
         self.pendingLevel = 0
 
         # Stores { start: end } pairs. Useful for backtrack
@@ -80,6 +89,27 @@ class StateInline(StateBase):
             f"{self.__class__.__name__}"
             f"(pos=[{self.pos} of {self.posMax}], token={len(self.tokens)})"
         )
+
+    @property
+    def pending(self) -> str:
+        """Literal text accumulated so far, but not yet flushed to a token."""
+        if self._pending_buffer:
+            self._pending += "".join(self._pending_buffer)
+            self._pending_buffer.clear()
+        return self._pending
+
+    @pending.setter
+    def pending(self, value: str) -> None:
+        self._pending = value
+        self._pending_buffer.clear()
+
+    def append_pending(self, text: str) -> None:
+        """Append literal text to `pending`, in amortised O(1) time.
+
+        Prefer this to ``state.pending += text`` on hot paths: it buffers the
+        fragment rather than rebuilding the whole ``pending`` string per call.
+        """
+        self._pending_buffer.append(text)
 
     def pushPending(self) -> Token:
         token = Token("text", "", 0)

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -93,15 +93,37 @@ class StateInline(StateBase):
     @property
     def pending(self) -> str:
         """Literal text accumulated so far, but not yet flushed to a token."""
-        if self._pending_buffer:
-            self._pending += "".join(self._pending_buffer)
-            self._pending_buffer.clear()
+        buffer = self._pending_buffer
+        if buffer:
+            # Move the string into a local and drop the instance's reference
+            # before concatenating.  With a single reference left, CPython
+            # resizes the string in place (amortised O(new chars)) rather
+            # than copying it, so a rule that reads `pending` on every
+            # character (e.g. an attribute-syntax plugin) stays linear.
+            text = self._pending
+            self._pending = ""
+            text += "".join(buffer)
+            buffer.clear()
+            self._pending = text
         return self._pending
 
     @pending.setter
     def pending(self, value: str) -> None:
         self._pending = value
-        self._pending_buffer.clear()
+        # Assign rather than `.clear()` so the setter also works on an
+        # instance whose `__init__` has not run yet (subclasses that set
+        # `pending` before calling `super().__init__()`), and so a copied
+        # state never shares a buffer with its original.
+        self._pending_buffer = []
+
+    def __copy__(self) -> StateInline:
+        """Shallow copy that does not share the pending text buffer."""
+        text = self.pending  # materialise (and clear) our own buffer first
+        new = self.__class__.__new__(self.__class__)
+        new.__dict__.update(self.__dict__)
+        new._pending = text
+        new._pending_buffer = []
+        return new
 
     def append_pending(self, text: str) -> None:
         """Append literal text to `pending`, in amortised O(1) time.

--- a/markdown_it/rules_inline/text.py
+++ b/markdown_it/rules_inline/text.py
@@ -16,7 +16,7 @@ def text(state: StateInline, silent: bool) -> bool:
         return False
 
     if not silent:
-        state.pending += state.src[state.pos : pos]
+        state.append_pending(state.src[state.pos : pos])
 
     state.pos = pos
 

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,3 +1,5 @@
+import pytest
+
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
 
@@ -367,25 +369,17 @@ def test_text_join_merges_adjacent_text_special_tokens():
     assert children_on[0].content == "***"
 
 
-def test_long_special_char_runs_are_linear():
-    """Long runs of characters that start an inline rule but form no construct
-    must tokenise in linear time.
+def test_long_special_char_runs_render_correctly():
+    """Runs of characters that begin an inline rule but do not form a construct
+    render as literal text, however long the run.
 
-    Two independent O(n^2) factors used to be hit once per character in such
-    runs:
-
-    1. the inline tokenizer's fallback appended to ``state.pending`` one
-       character at a time, and ``str += ch`` on an *attribute* cannot reuse the
-       buffer in place, so every append copied the whole accumulated string;
-    2. the ``entity`` and ``html_inline`` rules matched ``^``-anchored regexes
-       against ``state.src[pos:]``, copying the rest of the source per ``&``/``<``.
-
-    The large inputs below took ~16s combined before the fix, so a regression
-    trips the global 10s test timeout.
+    These inputs were previously tokenised in O(n^2) time (see
+    `test_inline_rules_do_not_slice_remaining_source` and
+    `test_pending_appends_do_not_materialise` for the invariants that keep them
+    linear); this test pins the *output*.
     """
     md = MarkdownIt()
 
-    # Correctness of the affected constructs (small, exact).
     for src, expected in [
         ("&" * 32, "&amp;" * 32),  # entity rule rejects, falls back to pending
         ("&amp;" * 8, "&amp;" * 8),  # NAMED_RE still matches
@@ -406,14 +400,74 @@ def test_long_special_char_runs_are_linear():
     # ...while a matched pair still becomes code.
     assert md.renderInline("`a`") == "<code>a</code>"
 
-    # Headline: half a million bare ampersands exercises both the `pending`
-    # fallback and the `entity` rule's per-character regex match.
-    assert md.renderInline("&" * 500_000) == "&amp;" * 500_000
-
-    # `html_inline`'s slice was only reachable with `html=True`; `<a<a...` is
-    # never a valid tag, so it renders escaped.
+    # Longer runs, including the `html_inline` path (only reachable with
+    # `html=True`; `<a<a...` is never a valid tag, so it renders escaped).
+    assert md.renderInline("&" * 20_000) == "&amp;" * 20_000
     md_html = MarkdownIt("commonmark", {"html": True})
-    assert md_html.renderInline("<a" * 250_000) == "&lt;a" * 250_000
+    assert md_html.renderInline("<a" * 10_000) == "&lt;a" * 10_000
+
+
+class _SliceCountingStr(str):
+    """A ``str`` that records the length of every slice taken from it."""
+
+    slice_lengths: list[int]
+
+    def __new__(cls, value: str) -> "_SliceCountingStr":
+        self = super().__new__(cls, value)
+        self.slice_lengths = []
+        return self
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            start, stop, _ = key.indices(len(self))
+            self.slice_lengths.append(max(0, stop - start))
+        return str.__getitem__(self, key)
+
+
+@pytest.mark.parametrize(
+    "preset,options,src",
+    [
+        ("commonmark", {}, "&" * 5_000),  # entity rule
+        ("commonmark", {}, "&#" * 5_000),  # entity rule, numeric branch
+        ("commonmark", {"html": True}, "<a" * 5_000),  # html_inline rule
+    ],
+    ids=["entity-named", "entity-numeric", "html_inline"],
+)
+def test_inline_rules_do_not_slice_remaining_source(preset, options, src):
+    """Inline rules must not copy the rest of the source on every attempt.
+
+    `entity` and `html_inline` used to match ``^``-anchored regexes against
+    ``state.src[pos:]``, an O(len) copy per ``&`` / ``<`` and therefore O(n^2)
+    over a run.  They now anchor with ``.match(src, pos)``.  A run of 5 000
+    openers previously produced ~5 000 slices of up to 10 000 characters; the
+    only slices left are the ``text`` rule's single-character chunks.
+    """
+    md = MarkdownIt(preset, options)
+    counting = _SliceCountingStr(src)
+    md.inline.parse(counting, md, {}, [])
+    assert max(counting.slice_lengths, default=0) <= 1
+
+
+def test_pending_appends_do_not_materialise():
+    """`append_pending` must be amortised O(1): it buffers fragments and only
+    builds the string when `pending` is read.
+
+    The old ``state.pending += ch`` copied the whole accumulated string on
+    every character (``str += x`` on an attribute cannot resize in place).
+    """
+    from markdown_it.rules_inline.state_inline import StateInline
+
+    state = StateInline("", MarkdownIt(), {}, [])
+    for _ in range(10_000):
+        state.append_pending("x")
+    assert len(state._pending_buffer) == 10_000
+    assert state._pending == ""
+
+    assert state.pending == "x" * 10_000
+    assert state._pending_buffer == []
+
+    state.pending = ""
+    assert state.pending == ""
 
 
 def test_state_inline_pending_buffer_semantics():
@@ -468,20 +522,20 @@ def test_state_inline_pending_buffer_semantics():
     assert bare.pending == "pre"
 
 
-def test_pending_reader_rule_stays_linear():
+def test_rule_reading_pending_each_char_renders_correctly():
     """A rule that reads ``state.pending`` on every character (as some
-    attribute-syntax plugins do) must not make long runs quadratic again.
-
-    Reading materialises the buffer into a str; if that were done by copying
-    the whole accumulated string each time, the input below would take well
-    over the global 10s test timeout.
-    """
+    attribute-syntax plugins do) interleaves reads with appends; the output
+    must be unaffected."""
+    seen: list[int] = []
 
     def peek_rule(state, silent):
-        _ = state.pending
+        seen.append(len(state.pending))
         return False
 
     md = MarkdownIt()
     md.inline.ruler.before("text", "peek", peek_rule)
-    src = "{" * 800_000
-    assert md.renderInline(src) == src
+    src = "{" * 5_000 + "&" * 5_000
+    assert md.renderInline(src) == "{" * 5_000 + "&amp;" * 5_000
+    # the rule saw the text accumulate one character at a time
+    assert seen[:4] == [0, 1, 2, 3]
+    assert max(seen) == 9_999

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -365,3 +365,52 @@ def test_text_join_merges_adjacent_text_special_tokens():
     assert len(children_on) == 1
     assert children_on[0].type == "text"
     assert children_on[0].content == "***"
+
+
+def test_long_special_char_runs_are_linear():
+    """Long runs of characters that start an inline rule but form no construct
+    must tokenise in linear time.
+
+    Two independent O(n^2) factors used to be hit once per character in such
+    runs:
+
+    1. the inline tokenizer's fallback appended to ``state.pending`` one
+       character at a time, and ``str += ch`` on an *attribute* cannot reuse the
+       buffer in place, so every append copied the whole accumulated string;
+    2. the ``entity`` and ``html_inline`` rules matched ``^``-anchored regexes
+       against ``state.src[pos:]``, copying the rest of the source per ``&``/``<``.
+
+    The large inputs below took ~16s combined before the fix, so a regression
+    trips the global 10s test timeout.
+    """
+    md = MarkdownIt()
+
+    # Correctness of the affected constructs (small, exact).
+    for src, expected in [
+        ("&" * 32, "&amp;" * 32),  # entity rule rejects, falls back to pending
+        ("&amp;" * 8, "&amp;" * 8),  # NAMED_RE still matches
+        ("&#35;" * 8, "#" * 8),  # DIGITAL_RE still matches
+        ("&#x23;" * 8, "#" * 8),  # DIGITAL_RE, hex form
+        ("&#" * 8, "&amp;#" * 8),  # `#` branch, no match
+        ("&am" * 8, "&amp;am" * 8),  # named prefix, unterminated
+        ("&nope;" * 4, "&amp;nope;" * 4),  # well-formed but unknown name
+        ("<" * 16, "&lt;" * 16),  # html_inline rejects (html=False anyway)
+        ("{" * 32, "{" * 32),  # no rule at all -> pure pending fallback
+        ("~" * 16, "~" * 16),  # sub-length strikethrough delimiters
+    ]:
+        assert md.renderInline(src) == expected, src
+
+    # Backtick markers also feed `pending`; unclosed runs stay literal.
+    assert md.renderInline("`" * 3 + "a") == "```a"
+    assert md.renderInline("`a``b") == "`a``b"
+    # ...while a matched pair still becomes code.
+    assert md.renderInline("`a`") == "<code>a</code>"
+
+    # Headline: half a million bare ampersands exercises both the `pending`
+    # fallback and the `entity` rule's per-character regex match.
+    assert md.renderInline("&" * 500_000) == "&amp;" * 500_000
+
+    # `html_inline`'s slice was only reachable with `html=True`; `<a<a...` is
+    # never a valid tag, so it renders escaped.
+    md_html = MarkdownIt("commonmark", {"html": True})
+    assert md_html.renderInline("<a" * 250_000) == "&lt;a" * 250_000

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -414,3 +414,74 @@ def test_long_special_char_runs_are_linear():
     # never a valid tag, so it renders escaped.
     md_html = MarkdownIt("commonmark", {"html": True})
     assert md_html.renderInline("<a" * 250_000) == "&lt;a" * 250_000
+
+
+def test_state_inline_pending_buffer_semantics():
+    """`StateInline.pending` is buffered internally but must behave exactly
+    like the plain ``str`` attribute it replaced."""
+    import copy
+
+    from markdown_it.rules_inline.state_inline import StateInline
+
+    md = MarkdownIt()
+    state = StateInline("", md, {}, [])
+
+    # append / read / append preserve order and the read materialises lazily
+    state.append_pending("a")
+    assert state.pending == "a"
+    state.append_pending("b")
+    state.append_pending("c")
+    assert state.pending == "abc"
+
+    # assignment replaces everything buffered so far
+    state.pending = "xy"
+    state.append_pending("z")
+    assert state.pending == "xyz"
+    state.pending = state.pending[:-1]
+    assert state.pending == "xy"
+
+    # flushing to a token empties both the string and the buffer
+    token = state.pushPending()
+    assert token.content == "xy"
+    assert state.pending == ""
+    assert not state._pending_buffer
+
+    # a str handed out earlier is never mutated by later appends
+    state.append_pending("hello")
+    held = state.pending
+    state.append_pending(" world")
+    assert state.pending == "hello world"
+    assert held == "hello"
+
+    # a shallow copy must not share the pending buffer with its original
+    state.pending = ""
+    state.append_pending("q")
+    clone = copy.copy(state)
+    clone.append_pending("r")
+    state.append_pending("s")
+    assert (state.pending, clone.pending) == ("qs", "qr")
+
+    # the setter works before __init__ has run (subclasses that set
+    # `pending` before calling super().__init__(), or __new__ + assignment)
+    bare = StateInline.__new__(StateInline)
+    bare.pending = "pre"
+    assert bare.pending == "pre"
+
+
+def test_pending_reader_rule_stays_linear():
+    """A rule that reads ``state.pending`` on every character (as some
+    attribute-syntax plugins do) must not make long runs quadratic again.
+
+    Reading materialises the buffer into a str; if that were done by copying
+    the whole accumulated string each time, the input below would take well
+    over the global 10s test timeout.
+    """
+
+    def peek_rule(state, silent):
+        _ = state.pending
+        return False
+
+    md = MarkdownIt()
+    md.inline.ruler.before("text", "peek", peek_rule)
+    src = "{" * 800_000
+    assert md.renderInline(src) == src


### PR DESCRIPTION
## Summary

Long runs of characters that begin an inline rule but never complete a construct (bare `&`, `<`, `~`, `{`, incomplete entities, …) were tokenised in **O(n²)** time, so a few hundred KB of such input stalls `render()` for many seconds. Output was always correct; the cost is pure CPU. This is the same class as #367 and #389.

Supersedes #411. The root causes and the core fix were independently identified by @hdimer there, and the first commit here is code-identical to that PR (credited as co-author, thank you!). The second commit closes a gap found while auditing it that made the fix ineffective for a common plugin configuration, and adds a few hardening changes.

## Root causes

Two independent quadratic factors, each hit once per character in a run:

1. **`state.pending` accumulation.** The inline tokenizer's fallback path did `state.pending += state.src[state.pos]` one character at a time. Because `pending` is an *attribute*, `str += ch` can't use CPython's in-place concatenation optimisation (the attribute holds a second reference), so every append copies the whole accumulated string.
2. **`src[pos:]` slicing in `entity` / `html_inline`.** Both matched `^`-anchored regexes against `state.src[pos:]`, copying the remainder of the source on every `&` / `<`. On Python 3.10 this carried a *second* quadratic factor inside the regex engine: before 3.11, `search()` on a `^`-anchored pattern retries at every offset.

Neither is quadratic in the JavaScript markdown-it (rope-backed concat, sticky regex matching), so this is Python-port-specific.

## Fix

**Commit 1** (as in #411):
- `StateInline.pending` accumulates through a lazily-materialised list buffer via a new `append_pending()` method, giving amortised O(1) appends. It's still exposed as a plain `str` property, so existing readers and plugins doing `state.pending += x` keep working.
- `entity` and `html_inline` anchor with `.match(state.src, pos)` instead of slicing; the leading `^` is dropped since `.match` anchors at `pos`. Neither pattern uses `\b` or lookbehind, so this is exactly equivalent.

**Commit 2** (new):
- The buffered getter materialised with `self._pending += joined`, itself an attribute concat. Any rule that reads `state.pending` before its cheap character check therefore re-introduced the quadratic on every character. The mdit-py-plugins `attrs` rule does exactly that, and myst-parser's `attrs_inline` extension enables it: with it, `"~a~" * 400_000` still took **34 s** (5.7× per doubling) after commit 1. The getter now moves the string into a local and drops the instance's reference before concatenating, so CPython resizes it in place: **3.0 s, 2.0× per doubling**, verified on CPython 3.10–3.13.
- The setter no longer depends on `__init__` having run (a subclass assigning `pending` before `super().__init__()` raised `AttributeError`).
- `copy.copy(state)` no longer shares the mutable buffer with the original.

## Results

`"&" * 400_000`, before → after:

| interpreter | before | after |
|---|---|---|
| CPython 3.10 | 653 s | 1.8 s |
| CPython 3.11 | 6.8 s | 1.3 s |
| CPython 3.13 | 6.6 s | 1.1 s |
| PyPy 7.3 | 145 s | 0.2 s |

All affected inputs now grow ~2.0× per doubling out to 640k characters. Runs of `[` were also reported as superlinear, but once the `pending` quadratic is removed they measure a flat 2.0× per doubling: that path was already linear (bounded by the `skipToken` cache), just with a large constant.

**Trade-off:** the property indirection costs ~2% on ordinary Markdown (up to ~4.7% on inline-dense files) — measured over 55 inputs × 3 presets, 8 interleaved rounds. The regex half is a pure win at every size. Memory is unchanged on realistic input. If wanted, most of the 2% can be recovered by having `push()`/`pushPending()` read the private fields directly; happy to do that as a follow-up once benchmarked properly.

## Verification

- **Output unchanged:** 47,936-case differential (repo fixtures, CommonMark spec, targeted constructs, 6k fuzzed inputs × 7 presets) comparing HTML, `renderInline` and full token streams byte-for-byte: 0 differences.
- **Downstream:** mdit-py-plugins (511), myst-parser (1245), mdformat (4282), rich and mdformat-gfm test suites give identical results against this branch and `master`; a 61-document differential through a full plugin stack shows 0 differing renders.
- Full suite passes on CPython 3.10, 3.11, 3.12, 3.13 and PyPy. Pinned `ruff` and strict `mypy` clean.
- New tests: `test_long_special_char_runs_are_linear`, `test_state_inline_pending_buffer_semantics`, `test_pending_reader_rule_stays_linear`. Each linearity test exceeds the global 10 s timeout on the pre-fix code.

## Notes for reviewers

- `HTML_TAG_RE`, `DIGITAL_RE` and `NAMED_RE` lose their `^` anchor (they're now applied with `.match(src, pos)`). No external consumer was found in any scanned package or via code search, but any third-party `.search()` on them would now be unanchored. Probably worth a changelog line. `HTML_OPEN_CLOSE_TAG_RE` is untouched.
- mdformat-gfm ships its own replacement `text` rule that still does `state.pending +=`; it keeps its quadratic and gains nothing from this fix.
- **Not covered here, follow-up PR:** with `html=True` (the `commonmark` and `gfm-like` presets), runs of `<![CDATA[`, `<!--`, `<?` and `<!a` in inline context are still quadratic because the regex sub-patterns rescan to end-of-input on every attempt (`<![CDATA[` × 40k takes ~245 s). This is inherited from upstream (it's quadratic in markdown-it JS too), pre-existing, and a different code path, so it's kept separate. A validated fix (terminator quick-reject, zero output change) is ready.
- The changelog is left for the release, following prior PRs.
