### PR TITLE
🔧 Update pre-commit hooks (ruff 0.16.6, mypy 2.3.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,14 +24,14 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.16.6
     hooks:
     - id: ruff
       args: [--fix]
     - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+    rev: v2.3.1
     hooks:
     - id: mypy
       additional_dependencies: [mdurl, typing-extensions]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,11 +158,9 @@ from __future__ import annotations
 
 from typing import Sequence
 
+
 def parse_blocks(
-    state: StateBlock,
-    start_line: int,
-    end_line: int,
-    silent: bool = False
+    state: StateBlock, start_line: int, end_line: int, silent: bool = False
 ) -> bool:
     """Parse block-level content.
 
@@ -293,18 +291,20 @@ HTML Output
 import pytest
 from markdown_it import MarkdownIt
 
+
 def test_basic_parsing():
     md = MarkdownIt()
     result = md.render("# Heading\n\nParagraph")
     assert "<h1>Heading</h1>" in result
     assert "<p>Paragraph</p>" in result
 
+
 @pytest.mark.parametrize(
     "input_text,expected",
     [
         ("**bold**", "<strong>bold</strong>"),
         ("*italic*", "<em>italic</em>"),
-    ]
+    ],
 )
 def test_emphasis(input_text, expected):
     md = MarkdownIt()
@@ -389,7 +389,7 @@ for token in tokens:
 print(md.get_all_rules())
 
 # Enable/disable specific rules
-md.disable(['emphasis'])
+md.disable(["emphasis"])
 result = md.render("*text*")  # Won't be emphasized
 ```
 
@@ -401,13 +401,13 @@ result = md.render("*text*")  # Won't be emphasized
 2. Create rule function in appropriate `rules_*/` directory
 3. Rule signature for block rules:
    ```python
-   def rule_name(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool:
-       ...
+   def rule_name(
+       state: StateBlock, startLine: int, endLine: int, silent: bool
+   ) -> bool: ...
    ```
 4. Rule signature for inline rules:
    ```python
-   def rule_name(state: StateInline, silent: bool) -> bool:
-       ...
+   def rule_name(state: StateInline, silent: bool) -> bool: ...
    ```
 5. Register the rule in the appropriate parser's `__init__` method
 6. Add tests for the new rule
@@ -434,10 +434,12 @@ result = md.render("*text*")  # Won't be emphasized
 ```python
 from markdown_it import MarkdownIt
 
+
 def render_custom_link(self, tokens, idx, options, env):
     tokens[idx].attrSet("target", "_blank")
     tokens[idx].attrSet("rel", "noopener noreferrer")
     return self.renderToken(tokens, idx, options, env)
+
 
 md = MarkdownIt()
 md.add_render_rule("link_open", render_custom_link)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,7 @@ It can then be activated by:
 
 ```python
 from markdown_it import MarkdownIt
+
 md = MarkdownIt().enable("linkify")
 md.options["linkify"] = True
 ```
@@ -284,6 +285,7 @@ It can be activated by:
 
 ```python
 from markdown_it import MarkdownIt
+
 md = MarkdownIt().enable("smartquotes")
 md.options["typographer"] = True
 ```
@@ -304,6 +306,7 @@ This plugin can be activated by:
 ```python
 from markdown_it import MarkdownIt
 from markdown_it.extensions.tasklists import tasklists_plugin
+
 md = MarkdownIt().use(tasklists_plugin)
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ from mdit_py_plugins.front_matter import front_matter_plugin
 from mdit_py_plugins.footnote import footnote_plugin
 
 md = (
-    MarkdownIt('commonmark', {'breaks':True,'html':True})
+    MarkdownIt("commonmark", {"breaks": True, "html": True})
     .use(front_matter_plugin)
     .use(footnote_plugin)
-    .enable('table')
+    .enable("table")
 )
-text = ("""
+text = """
 ---
 a: 1
 ---
@@ -86,7 +86,7 @@ a | b
 A footnote [^1]
 
 [^1]: some details
-""")
+"""
 tokens = md.parse(text)
 html_text = md.render(text)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@ with the same signature:
 
 ```python
 def function(renderer, tokens, idx, options, env):
-  return htmlResult
+    return htmlResult
 ```
 
 In many cases that allows easy output change even without parser intrusion.
@@ -113,22 +113,27 @@ For example, let's replace images with vimeo links to player's iframe:
 
 ```python
 import re
+
 md = MarkdownIt("commonmark")
 
-vimeoRE = re.compile(r'^https?:\/\/(www\.)?vimeo.com\/(\d+)($|\/)')
+vimeoRE = re.compile(r"^https?:\/\/(www\.)?vimeo.com\/(\d+)($|\/)")
+
 
 def render_vimeo(self, tokens, idx, options, env):
     token = tokens[idx]
 
     if vimeoRE.match(token.attrs["src"]):
-
         ident = vimeoRE.match(token.attrs["src"])[2]
 
-        return ('<div class="embed-responsive embed-responsive-16by9">\n' +
-               '  <iframe class="embed-responsive-item" src="//player.vimeo.com/video/' +
-                ident + '"></iframe>\n' +
-               '</div>\n')
+        return (
+            '<div class="embed-responsive embed-responsive-16by9">\n'
+            + '  <iframe class="embed-responsive-item" src="//player.vimeo.com/video/'
+            + ident
+            + '"></iframe>\n'
+            + "</div>\n"
+        )
     return self.image(tokens, idx, options, env)
+
 
 md = MarkdownIt("commonmark")
 md.add_render_rule("image", render_vimeo)
@@ -140,11 +145,13 @@ Here is another example, how to add `target="_blank"` to all links:
 ```python
 from markdown_it import MarkdownIt
 
+
 def render_blank_link(self, tokens, idx, options, env):
     tokens[idx].attrSet("target", "_blank")
 
     # pass token to default renderer.
     return self.renderToken(tokens, idx, options, env)
+
 
 md = MarkdownIt("commonmark")
 md.add_render_rule("link_open", render_blank_link)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ nitpick_ignore_regex = [
         "Path",
         "Ellipsis",
         "NotRequired",
+        "Self",
     )
 ]
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,14 +13,16 @@ These can be enabled individually:
 
 ```python
 from markdown_it import MarkdownIt
-md = MarkdownIt("commonmark").enable('table')
+
+md = MarkdownIt("commonmark").enable("table")
 ```
 
 or as part of a configuration:
 
 ```python
 from markdown_it import MarkdownIt
-md = MarkdownIt("gfm-like")   # tables, strikethrough, linkify
+
+md = MarkdownIt("gfm-like")  # tables, strikethrough, linkify
 md = MarkdownIt("gfm-like2")  # + task lists, alerts, single-tilde strikethrough
 ```
 
@@ -48,6 +50,7 @@ They can be chained and loaded *via*:
 ```python
 from markdown_it import MarkdownIt
 from mdit_py_plugins import plugin1, plugin2
+
 md = MarkdownIt().use(plugin1, keyword=value).use(plugin2, keyword=value)
 html_string = md.render("some *Markdown*")
 ```

--- a/docs/using.md
+++ b/docs/using.md
@@ -298,7 +298,7 @@ with the same signature:
 
 ```python
 def function(renderer, tokens, idx, options, env):
-  return htmlResult
+    return htmlResult
 ```
 
 +++

--- a/markdown_it/cli/parse.py
+++ b/markdown_it/cli/parse.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 CLI interface to markdown-it-py
 

--- a/markdown_it/common/utils.py
+++ b/markdown_it/common/utils.py
@@ -102,7 +102,7 @@ def replaceEntityPattern(match: str, name: str) -> str:
     if name in entities:
         return entities[name]
 
-    code: None | int = None
+    code: int | None = None
     if pat := DIGITAL_ENTITY_BASE10_RE.fullmatch(name):
         code = int(pat.group(1), 10)
     elif pat := DIGITAL_ENTITY_BASE16_RE.fullmatch(name):

--- a/markdown_it/renderer.py
+++ b/markdown_it/renderer.py
@@ -61,7 +61,7 @@ class RendererHTML(RendererProtocol):
         self.rules = {
             k: v
             for k, v in inspect.getmembers(self, predicate=inspect.ismethod)
-            if not (k.startswith("render") or k.startswith("_"))
+            if not k.startswith(("render", "_"))
         }
 
     def render(

--- a/markdown_it/rules_block/fence.py
+++ b/markdown_it/rules_block/fence.py
@@ -37,10 +37,10 @@ def make_fence_rule(
     closing_matcher: Callable[[int, int], bool]
     if exact_match:
         # closing code fence must have exactly the same number of markers as the opening one
-        closing_matcher = lambda opening_len, closing_len: closing_len == opening_len  # noqa: E731
+        closing_matcher = lambda opening_len, closing_len: closing_len == opening_len
     else:
         # closing code fence must be at least as long as the opening one
-        closing_matcher = lambda opening_len, closing_len: closing_len >= opening_len  # noqa: E731
+        closing_matcher = lambda opening_len, closing_len: closing_len >= opening_len
 
     def _fence_rule(
         state: StateBlock, startLine: int, endLine: int, silent: bool

--- a/markdown_it/rules_block/reference.py
+++ b/markdown_it/rules_block/reference.py
@@ -192,7 +192,7 @@ def reference(state: StateBlock, startLine: int, _endLine: int, silent: bool) ->
     return True
 
 
-def getNextLine(state: StateBlock, nextLine: int) -> None | str:
+def getNextLine(state: StateBlock, nextLine: int) -> str | None:
     endLine = state.lineMax
 
     if nextLine >= endLine or state.isEmpty(nextLine):

--- a/markdown_it/rules_core/smartquotes.py
+++ b/markdown_it/rules_core/smartquotes.py
@@ -58,7 +58,7 @@ def process_inlines(tokens: list[Token], state: StateCore) -> None:
 
             # Find previous character,
             # default to space if it's the beginning of the line
-            lastChar: None | int = 0x20
+            lastChar: int | None = 0x20
 
             if t.start(0) + lastIndex - 1 >= 0:
                 lastChar = charCodeAt(text, t.start(0) + lastIndex - 1)
@@ -75,7 +75,7 @@ def process_inlines(tokens: list[Token], state: StateCore) -> None:
 
             # Find next character,
             # default to space if it's the end of the line
-            nextChar: None | int = 0x20
+            nextChar: int | None = 0x20
 
             if pos < maximum:
                 nextChar = charCodeAt(text, pos)

--- a/markdown_it/token.py
+++ b/markdown_it/token.py
@@ -95,11 +95,11 @@ class Token:
         name, value = attrData
         self.attrSet(name, value)
 
-    def attrSet(self, name: str, value: str | int | float) -> None:
+    def attrSet(self, name: str, value: str | float) -> None:
         """Set `name` attribute to `value`. Override old value if exists."""
         self.attrs[name] = value
 
-    def attrGet(self, name: str) -> None | str | int | float:
+    def attrGet(self, name: str) -> str | int | float | None:
         """Get the value of attribute `name`, or null if it does not exist."""
         return self.attrs.get(name, None)
 

--- a/markdown_it/tree.py
+++ b/markdown_it/tree.py
@@ -9,6 +9,8 @@ from collections.abc import Generator, Sequence
 import textwrap
 from typing import Any, NamedTuple, TypeVar, overload
 
+from typing_extensions import Self
+
 from .token import Token
 
 
@@ -84,13 +86,13 @@ class SyntaxTreeNode:
     @overload
     def __getitem__(self: _NodeType, item: slice) -> list[_NodeType]: ...
 
-    def __getitem__(self: _NodeType, item: int | slice) -> _NodeType | list[_NodeType]:
+    def __getitem__(self, item: int | slice) -> Self | list[Self]:
         return self.children[item]
 
-    def to_tokens(self: _NodeType) -> list[Token]:
+    def to_tokens(self) -> list[Token]:
         """Recover the linear token stream."""
 
-        def recursive_collect_tokens(node: _NodeType, token_list: list[Token]) -> None:
+        def recursive_collect_tokens(node: Self, token_list: list[Token]) -> None:
             if node.type == "root":
                 for child in node.children:
                     recursive_collect_tokens(child, token_list)
@@ -108,19 +110,19 @@ class SyntaxTreeNode:
         return tokens
 
     @property
-    def children(self: _NodeType) -> list[_NodeType]:
+    def children(self) -> list[Self]:
         return self._children
 
     @children.setter
-    def children(self: _NodeType, value: list[_NodeType]) -> None:
+    def children(self, value: list[Self]) -> None:
         self._children = value
 
     @property
-    def parent(self: _NodeType) -> _NodeType | None:
+    def parent(self) -> Self | None:
         return self._parent  # type: ignore
 
     @parent.setter
-    def parent(self: _NodeType, value: _NodeType | None) -> None:
+    def parent(self, value: Self | None) -> None:
         self._parent = value
 
     @property
@@ -139,7 +141,7 @@ class SyntaxTreeNode:
         return bool(self.nester_tokens)
 
     @property
-    def siblings(self: _NodeType) -> Sequence[_NodeType]:
+    def siblings(self) -> Sequence[Self]:
         """Get siblings of the node.
 
         Gets the whole group of siblings, including self.
@@ -165,7 +167,7 @@ class SyntaxTreeNode:
         return self.nester_tokens.opening.type.removesuffix("_open")
 
     @property
-    def next_sibling(self: _NodeType) -> _NodeType | None:
+    def next_sibling(self) -> Self | None:
         """Get the next node in the sequence of siblings.
 
         Returns `None` if this is the last sibling.
@@ -176,7 +178,7 @@ class SyntaxTreeNode:
         return None
 
     @property
-    def previous_sibling(self: _NodeType) -> _NodeType | None:
+    def previous_sibling(self) -> Self | None:
         """Get the previous node in the sequence of siblings.
 
         Returns `None` if this is the first sibling.
@@ -241,9 +243,7 @@ class SyntaxTreeNode:
             )
         return text
 
-    def walk(
-        self: _NodeType, *, include_self: bool = True
-    ) -> Generator[_NodeType, None, None]:
+    def walk(self, *, include_self: bool = True) -> Generator[Self, None, None]:
         """Recursively yield all descendant nodes in the tree starting at self.
 
         The order mimics the order of the underlying linear token
@@ -282,7 +282,7 @@ class SyntaxTreeNode:
         """Html attributes."""
         return self._attribute_token().attrs
 
-    def attrGet(self, name: str) -> None | str | int | float:
+    def attrGet(self, name: str) -> str | int | float | None:
         """Get the value of attribute `name`, or null if it does not exist."""
         return self._attribute_token().attrGet(name)
 

--- a/markdown_it/tree.py
+++ b/markdown_it/tree.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 
 from collections.abc import Generator, Sequence
 import textwrap
-from typing import Any, NamedTuple, TypeVar, overload
-
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, overload
 
 from .token import Token
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 class _NesterTokens(NamedTuple):

--- a/markdown_it/utils.py
+++ b/markdown_it/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, MutableMapping
+from collections.abc import Callable, Iterator, MutableMapping
 from collections.abc import MutableMapping as MutableMappingABC
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict, cast
@@ -78,7 +78,7 @@ class OptionsDict(MutableMappingABC):  # type: ignore
     def __delitem__(self, key: str) -> None:
         del self._options[key]  # type: ignore
 
-    def __iter__(self) -> Iterable[str]:  # type: ignore
+    def __iter__(self) -> Iterator[str]:
         return iter(self._options)
 
     def __len__(self) -> int:

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 def test_get_rules():
@@ -412,7 +417,7 @@ class _SliceCountingStr(str):
 
     slice_lengths: list[int]
 
-    def __new__(cls, value: str) -> "_SliceCountingStr":
+    def __new__(cls, value: str) -> "Self":
         self = super().__new__(cls, value)
         self.slice_lengths = []
         return self

--- a/tests/test_cmark_spec/get_cmark_spec.py
+++ b/tests/test_cmark_spec/get_cmark_spec.py
@@ -55,7 +55,7 @@ def _json_to_fixture(data: list[dict[str, Any]]) -> str:
 
 
 if __name__ == "__main__":
-    import requests  # type: ignore[import-untyped]
+    import requests
 
     args = create_argparser().parse_args()
     version: str = args.version


### PR DESCRIPTION
## Summary

A fresh `pre-commit autoupdate` on current master, replacing #396 (the bot's May branch), whose CI was red because the ruff autofix had inserted an unguarded `from typing_extensions import Self` into `markdown_it/tree.py` while `typing_extensions` is not a runtime dependency.

| hook | before | after |
|---|---|---|
| `astral-sh/ruff-pre-commit` | v0.15.12 | v0.16.6 |
| `pre-commit/mirrors-mypy` | v1.20.2 | v2.3.1 |
| `pre-commit/pre-commit-hooks` | v6.0.0 | v6.0.0 (unchanged) |

Two commits: the hook bump plus the hooks' own auto-fixes, then the manual fixes for what remained. The first commit alone is not runtime-safe (see below), so squash-merge is the right choice here.

## What changed and why

**Runtime-safety fix.** ruff's PYI019 autofix rewrites the `self: _NodeType` pattern in `SyntaxTreeNode` to `Self`, importing it from `typing_extensions`. That import is now under `if TYPE_CHECKING:` (the module already has `from __future__ import annotations`, and every use of `Self` is annotation-only). Verified by importing `markdown_it.tree` and calling `SyntaxTreeNode(...).pretty()` with `typing_extensions` blocked via a meta-path finder. Nothing was added to `dependencies`.

**Manual lint fixes** (all from ruff 0.16's expanded default rule set, none from rules this repo selects):
- `EXE001`: removed the vestigial shebang from `markdown_it/cli/parse.py` (the CLI ships via the console script; `python -m markdown_it.cli.parse` still works).
- `PIE810`: `k.startswith(("render", "_"))` in `renderer.py`.
- `PYI045`: `OptionsDict.__iter__` now declares `Iterator[str]` (it always returned one), dropping a `type: ignore`.
- `PYI034`: `__new__` in a test helper annotated with `Self`.
- `RUF036`/`UP045`: `None | X` unions reordered to `X | None`. Type-equivalent.
- mypy 2.3: one now-unused `type: ignore[import-untyped]` removed.

**Autofix changes worth knowing about** (all type-equivalent or comment-only):
- `Token.attrSet(value: str | int | float)` now reads `str | float` (PYI041). Under PEP 484's numeric tower `float` already accepts `int`, so nothing changes for callers, but rendered signatures will look narrower.
- Two `# noqa: E731` comments in `fence.py` removed by RUF100: ruff 0.16 no longer flags those lambdas, so the comments were dead, and the hook auto-removes them if restored.
- ruff-format 0.16 now formats Python code inside Markdown fences, hence the diffs in `README.md`, `AGENTS.md`, `CHANGELOG.md` and `docs/`. All are formatting-only inside fenced examples (quotes, wrapping, `...` stubs); no prose changed.

## For the maintainers to decide (not changed here)

With `pyproject.toml` untouched, ruff 0.16.6 enables **463** rules versus **253** under 0.15.12: the defaults grew substantially (EXE, PIE, PYI, UP007/UP045 and more are now on without being selected). It may be worth pinning an explicit `select` so future ruff releases don't silently change what's enforced.

## Verification

- `pre-commit run --all-files`: every hook passes under the new pins.
- 993 tests pass.
- `import markdown_it, markdown_it.tree, markdown_it.cli.parse` succeeds with `typing_extensions` unavailable.

Supersedes #396.