### PR TITLE
🔧 Include tests/ and tox.ini in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ rtd = [
 ]
 testing = [
     "coverage",
+    "flit_core>=3.4,<5",  # lets tests/test_packaging build the sdist
     "pytest",
     "pytest-cov",
     "pytest-regressions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,9 +81,12 @@ markdown-it = "markdown_it.cli.parse:main"
 name = "markdown_it"
 
 [tool.flit.sdist]
+include = [
+    "tests/",
+    "tox.ini",
+]
 exclude = [
     "docs/",
-    "tests/",
     "benchmarking/"
 ]
 

--- a/tests/test_packaging/test_sdist_includes_tests.py
+++ b/tests/test_packaging/test_sdist_includes_tests.py
@@ -3,23 +3,26 @@
 from __future__ import annotations
 
 from pathlib import Path
+import tarfile
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_flit_sdist_includes_tests_directory() -> None:
-    """sdist must ship tests/ (and tox.ini) so downstream packagers can run them."""
-    text = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(
-        encoding="utf-8"
-    )
-    # Locate the flit sdist table without requiring tomllib (3.10 CI).
-    start = text.index("[tool.flit.sdist]")
-    rest = text[start + len("[tool.flit.sdist]") :]
-    end = rest.find("\n[")
-    block = rest if end < 0 else rest[:end]
-    assert "include = [" in block
-    assert '"tests/"' in block
-    assert '"tox.ini"' in block
-    # Still exclude heavy non-test trees.
-    assert '"docs/"' in block
-    assert '"benchmarking/"' in block
-    # Must not exclude tests anymore.
-    assert '"tests/"' not in block.split("exclude", 1)[-1]
+def test_sdist_contents(tmp_path: Path) -> None:
+    """The sdist must ship tests/ and tox.ini, so downstream packagers can run them."""
+    flit_sdist = pytest.importorskip("flit_core.sdist")
+    if not (ROOT / "pyproject.toml").is_file():
+        pytest.skip("not running from a source checkout")
+
+    builder = flit_sdist.SdistBuilder.from_ini_path(ROOT / "pyproject.toml")
+    with tarfile.open(builder.build(tmp_path)) as tar:
+        # strip the leading `markdown_it-<version>/` component
+        names = {name.split("/", 1)[1] for name in tar.getnames() if "/" in name}
+
+    assert "markdown_it/__init__.py" in names
+    assert "tests/test_api/test_main.py" in names
+    assert "tox.ini" in names
+    # heavy, non-essential trees are still excluded
+    assert not [name for name in names if name.startswith(("docs/", "benchmarking/"))]

--- a/tests/test_packaging/test_sdist_includes_tests.py
+++ b/tests/test_packaging/test_sdist_includes_tests.py
@@ -1,0 +1,25 @@
+"""Regression for https://github.com/executablebooks/markdown-it-py/issues/261."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_flit_sdist_includes_tests_directory() -> None:
+    """sdist must ship tests/ (and tox.ini) so downstream packagers can run them."""
+    text = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    # Locate the flit sdist table without requiring tomllib (3.10 CI).
+    start = text.index("[tool.flit.sdist]")
+    rest = text[start + len("[tool.flit.sdist]") :]
+    end = rest.find("\n[")
+    block = rest if end < 0 else rest[:end]
+    assert 'include = [' in block
+    assert '"tests/"' in block
+    assert '"tox.ini"' in block
+    # Still exclude heavy non-test trees.
+    assert '"docs/"' in block
+    assert '"benchmarking/"' in block
+    # Must not exclude tests anymore.
+    assert '"tests/"' not in block.split("exclude", 1)[-1]

--- a/tests/test_packaging/test_sdist_includes_tests.py
+++ b/tests/test_packaging/test_sdist_includes_tests.py
@@ -15,7 +15,7 @@ def test_flit_sdist_includes_tests_directory() -> None:
     rest = text[start + len("[tool.flit.sdist]") :]
     end = rest.find("\n[")
     block = rest if end < 0 else rest[:end]
-    assert 'include = [' in block
+    assert "include = [" in block
     assert '"tests/"' in block
     assert '"tox.ini"' in block
     # Still exclude heavy non-test trees.


### PR DESCRIPTION
## Summary

Supersedes #420 by @BetterAndBetterII (GitHub refused to update that fork branch because the merge would carry workflow-file changes); their commits are carried here verbatim with authorship preserved (thank you!). Closes #261, open since 2023 from a distro packager.

PyPI sdists shipped `tox.ini` but omitted `tests/`, so packagers could not run the suite from the tarball. `tests/` is moved out of `[tool.flit.sdist] exclude` and `tests/` plus `tox.ini` are explicitly included; `docs/` and `benchmarking/` stay excluded.

## Commits

1. `fix: include tests/ (and tox.ini) in the flit sdist` and the pre-commit.ci autofix — the contributor's commits, unchanged.
2. `🧪 TEST: Assert sdist contents by building the sdist` — the original test only string-matched `pyproject.toml`. It now builds a real sdist with `flit_core` (no network, ~0.15 s) and asserts `markdown_it/__init__.py`, `tests/test_api/test_main.py` and `tox.ini` are members and nothing under `docs/` or `benchmarking/` is. It skips cleanly when `flit_core` is unavailable or when not run from a source checkout. Verified negative: with the `include` reverted, the test fails on `tests/test_api/test_main.py`.

## Verification

- 994 tests pass; the sdist test runs (not skipped) with flit_core 4.0.2, which is what `pyproject.toml` now allows after #414.
- All pre-commit hooks pass under the new pins.
- No changelog entry in the commits; suggest adding one at release time under 🔧.

