### PR TITLE
🔧 Remove optional dependency on the unmaintained `commonmark` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * ✨ Add `--enable-tables` to the CLI for file, standard input and interactive parsing in [#422](https://github.com/executablebooks/markdown-it-py/pull/422)
 * 🐛 Fix CLI interactive mode joining input lines with an extra newline, which split every line into its own paragraph and broke hard line breaks, in [#172](https://github.com/executablebooks/markdown-it-py/issues/172)
 * 📚 Document the Python renderer constructor contract.
-* 🔧 Drop the optional dependency on the `commonmark` package, and its benchmark and performance table row, since the upstream package is unmaintained, in [#401](https://github.com/executablebooks/markdown-it-py/pull/401)
+* 🔧 Drop the optional dependency on the `commonmark` package and its benchmark, since the upstream package is unmaintained, in [#401](https://github.com/executablebooks/markdown-it-py/pull/401)
 
 ## 4.2.0 - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * 📚 Document the Python renderer constructor contract.
+* 🔧 Drop the optional dependency on the `commonmark` package, and its benchmark and performance table row, since the upstream package is unmaintained, in [#401](https://github.com/executablebooks/markdown-it-py/pull/401)
 
 ## 4.2.0 - 2026-05-07
 

--- a/benchmarking/bench_packages.py
+++ b/benchmarking/bench_packages.py
@@ -36,14 +36,6 @@ def test_mistune(benchmark, spec_text):
 
 
 @pytest.mark.benchmark(group="packages")
-def test_commonmark_py(benchmark, spec_text):
-    import commonmark
-
-    benchmark.extra_info["version"] = "0.9.1"
-    benchmark(commonmark.commonmark, spec_text)
-
-
-@pytest.mark.benchmark(group="packages")
 def test_pymarkdown(benchmark, spec_text):
     import markdown
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -15,7 +15,6 @@ tox -e py311-bench-packages -- --benchmark-columns mean,stddev
 | mistune[^2]          | 3.0.1   | 80.409    | 2.335   |
 | **markdown-it-py**   | 3.0.0   | 97.242    | 4.427   |
 | mistletoe            | 1.1.0   | 99.633    | 4.628   |
-| commonmark-py        | 0.9.1   | 300.403   | 9.706   |
 | pymarkdown           | 3.4.3   | 387.775   | 10.394  |
 | pymarkdown (+extras) | 3.4.3   | 646.564   | 11.316  |
 | panflute             | 2.3.0   | 860.105   | 208.607 |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -15,6 +15,7 @@ tox -e py311-bench-packages -- --benchmark-columns mean,stddev
 | mistune[^2]          | 3.0.1   | 80.409    | 2.335   |
 | **markdown-it-py**   | 3.0.0   | 97.242    | 4.427   |
 | mistletoe            | 1.1.0   | 99.633    | 4.628   |
+| commonmark-py[^3]    | 0.9.1   | 300.403   | 9.706   |
 | pymarkdown           | 3.4.3   | 387.775   | 10.394  |
 | pymarkdown (+extras) | 3.4.3   | 646.564   | 11.316  |
 | panflute             | 2.3.0   | 860.105   | 208.607 |
@@ -25,3 +26,4 @@ As you can see, `markdown-it-py` doesn't pay with speed for its flexibility.
 [^2]: `mistune` is not CommonMark compliant, which is what allows for its
 faster parsing, at the expense of issues, for example, with nested inline parsing.
 See [mistletoe's explanation](https://github.com/miyuchina/mistletoe/blob/master/performance.md) for further details.
+[^3]: `commonmark-py` is deprecated and no longer maintained (its last release was in 2019), so it has been removed from the benchmark suite; the figures shown are from the last run that included it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ Documentation = "https://markdown-it-py.readthedocs.io"
 
 [project.optional-dependencies]
 compare = [
-    "commonmark~=0.9",
     "markdown~=3.4",
     "mistletoe~=1.0",
     "mistune~=3.0",


### PR DESCRIPTION
## Summary

Supersedes #401 by @nikolas, whose fork does not allow maintainer pushes; their commit is carried here verbatim with authorship preserved (thank you!).

The `commonmark` PyPI package was deprecated in 2022 (last release 2019). #401 dropped it from the `compare` extra but left `benchmarking/bench_packages.py::test_commonmark_py` importing it unguarded, so `tox -e py311-bench-packages` (which installs `benchmarking,compare`) would have errored. This PR removes that benchmark too.

The `commonmark-py` row in `docs/performance.md` is **kept**, with a footnote explaining that the package is deprecated, has been removed from the benchmark suite, and that the figures are from the last run that included it. The historical comparison is still informative.

A changelog line with the rationale is added.

## Commits

1. `Remove optional dependency on commonmark` — the contributor's commit, unchanged.
2. `🔧 MAINTAIN: Remove remaining commonmark references` — drops the orphaned benchmark, adds the changelog line.
3. `📚 DOCS: Keep the commonmark-py benchmark row, with a deprecation footnote`, plus a changelog wording tweak.

## Verification

- All tests pass; all pre-commit hooks pass under the new pins.
- Local docs build renders the footnote and adds no warnings over master.
- Remaining `commonmark` mentions in `pyproject.toml`, `tox.ini` and `benchmarking/` refer to the CommonMark spec or the `commonmark` preset, none to the package.