### PR TITLE
👌 Reject unterminated inline HTML in constant time

### DIFF
--- a/markdown_it/rules_inline/html_inline.py
+++ b/markdown_it/rules_inline/html_inline.py
@@ -17,22 +17,50 @@ def html_inline(state: StateInline, silent: bool) -> bool:
         return False
 
     # Check start
+    src = state.src
     maximum = state.posMax
-    if state.src[pos] != "<" or pos + 2 >= maximum:
+    if src[pos] != "<" or pos + 2 >= maximum:
         return False
 
     # Quick fail on second char
-    ch = state.src[pos + 1]
+    ch = src[pos + 1]
     if ch not in ("!", "?", "/") and not isLetter(ord(ch)):  # /* / */
         return False
 
-    match = HTML_TAG_RE.match(state.src, pos)
+    # Every alternative of the tag regex ends with a specific terminator, at a
+    # known minimum offset from `pos`.  If that terminator does not occur
+    # anywhere at or after this offset, no match is possible; bail out before
+    # running the regex, whose lazy sub-patterns would scan to the end of the
+    # input.  Without this, a run of unterminated openers is quadratic.
+    if src.startswith("<!--", pos):
+        # `<!-->` / `<!--->`, else `<!--` ... `-->` (`<!---->` is the shortest)
+        if state.html_terminator_last(">") < pos + 4:
+            return False
+        if (
+            not src.startswith("<!-->", pos)
+            and not src.startswith("<!--->", pos)
+            and state.html_terminator_last("-->") < pos + 4
+        ):
+            return False
+    elif src.startswith("<![CDATA[", pos):
+        if state.html_terminator_last("]]>") < pos + 9:  # `<![CDATA[]]>`
+            return False
+    elif ch == "?":
+        if state.html_terminator_last("?>") < pos + 2:  # `<??>`
+            return False
+    elif ch == "!":
+        if state.html_terminator_last(">") < pos + 3:  # `<!a>`
+            return False
+    elif state.html_terminator_last(">") < pos + 2:  # `<a>`, `</a>`
+        return False
+
+    match = HTML_TAG_RE.match(src, pos)
     if not match:
         return False
 
     if not silent:
         token = state.push("html_inline", "", 0)
-        token.content = state.src[pos : pos + len(match.group(0))]
+        token.content = src[pos : pos + len(match.group(0))]
 
         if isLinkOpen(token.content):
             state.linkLevel += 1

--- a/markdown_it/rules_inline/state_inline.py
+++ b/markdown_it/rules_inline/state_inline.py
@@ -84,6 +84,27 @@ class StateInline(StateBase):
         # inside <a> and markdown links
         self.linkLevel = 0
 
+        # Lazy cache of `terminator -> last index in src`, see
+        # `html_terminator_last`.
+        self._html_terminators: dict[str, int] | None = None
+
+    def html_terminator_last(self, term: str) -> int:
+        """Index of the last occurrence of `term` in `self.src`, or -1.
+
+        The result is cached per terminator, for the life of the state.
+        It is used by the `html_inline` rule to reject, in constant time, a
+        position at which the terminator required to close an HTML construct
+        cannot possibly occur -- without running the tag regex, whose lazy
+        sub-patterns would otherwise rescan to the end of the input on every
+        such (failing) attempt.
+        """
+        if self._html_terminators is None:
+            self._html_terminators = {}
+        elif (last := self._html_terminators.get(term)) is not None:
+            return last
+        last = self._html_terminators[term] = self.src.rfind(term)
+        return last
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}"

--- a/tests/test_html_inline.py
+++ b/tests/test_html_inline.py
@@ -1,5 +1,7 @@
 """Tests for the `html_inline` rule."""
 
+import importlib
+
 import pytest
 
 from markdown_it import MarkdownIt
@@ -25,11 +27,48 @@ def test_shortest_constructs(src):
 
 
 @pytest.mark.parametrize("opener", ["<![CDATA[", "<!--", "<?", "<!a", "<a", "</a"])
-def test_unterminated_openers_are_linear(opener):
-    """A long run of openers that are never terminated must not be quadratic.
+def test_unterminated_openers_skip_the_regex(opener, monkeypatch):
+    """A run of openers that are never terminated must not run the tag regex.
 
-    Guarded by the global pytest timeout: before the terminator quick-reject
-    these took minutes rather than milliseconds.
+    Every alternative of ``HTML_TAG_RE`` ends in a specific terminator, and its
+    lazy sub-patterns rescan to the end of the input on each failed attempt,
+    which made such runs quadratic.  ``html_inline`` now rejects an opener in
+    constant time when the terminator it needs cannot occur, so the regex is
+    never invoked here; before the fix it ran once per opener.
     """
-    src = "x" + opener * 10_000  # leading "x" keeps it out of `html_block`
-    MarkdownIt("commonmark").render(src)
+    module = importlib.import_module("markdown_it.rules_inline.html_inline")
+
+    real = module.HTML_TAG_RE
+    calls = []
+
+    class Counting:
+        def match(self, *args, **kwargs):
+            calls.append(args[1] if len(args) > 1 else None)
+            return real.match(*args, **kwargs)
+
+    monkeypatch.setattr(module, "HTML_TAG_RE", Counting())
+    src = "x" + opener * 1_000  # leading "x" keeps it out of `html_block`
+    html = MarkdownIt("commonmark").render(src)
+    assert calls == []
+    # the openers all render as escaped text
+    assert html == "<p>x" + (opener.replace("<", "&lt;")) * 1_000 + "</p>\n"
+
+
+def test_terminated_constructs_still_reach_the_regex(monkeypatch):
+    """The quick-reject must be exactly that: a terminated construct is still
+    handed to the regex and parsed as before."""
+    module = importlib.import_module("markdown_it.rules_inline.html_inline")
+
+    real = module.HTML_TAG_RE
+    calls = []
+
+    class Counting:
+        def match(self, *args, **kwargs):
+            calls.append(1)
+            return real.match(*args, **kwargs)
+
+    monkeypatch.setattr(module, "HTML_TAG_RE", Counting())
+    src = "x <!-- c --> <?pi?> <![CDATA[d]]> <!D> <a>b</a>"
+    html = MarkdownIt("commonmark").render(src)
+    assert calls, "expected the regex to run for terminated constructs"
+    assert html == "<p>" + src + "</p>\n"

--- a/tests/test_html_inline.py
+++ b/tests/test_html_inline.py
@@ -1,0 +1,35 @@
+"""Tests for the `html_inline` rule."""
+
+import pytest
+
+from markdown_it import MarkdownIt
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "<a>",  # open tag
+        "<a/>",  # self-closing open tag
+        "</a>",  # close tag
+        "<!-->",  # short comment
+        "<!--->",  # short comment
+        "<!---->",  # shortest full comment
+        "<??>",  # empty processing instruction
+        "<!a>",  # declaration
+        "<![CDATA[]]>",  # empty CDATA section
+    ],
+)
+def test_shortest_constructs(src: str) -> None:
+    """The shortest legal form of each construct is passed through as raw html."""
+    assert MarkdownIt("commonmark").renderInline(src) == src
+
+
+@pytest.mark.parametrize("opener", ["<![CDATA[", "<!--", "<?", "<!a", "<a", "</a"])
+def test_unterminated_openers_are_linear(opener: str) -> None:
+    """A long run of openers that are never terminated must not be quadratic.
+
+    Guarded by the global pytest timeout: before the terminator quick-reject
+    these took minutes rather than milliseconds.
+    """
+    src = "x" + opener * 10_000  # leading "x" keeps it out of `html_block`
+    MarkdownIt("commonmark").render(src)

--- a/tests/test_html_inline.py
+++ b/tests/test_html_inline.py
@@ -19,13 +19,13 @@ from markdown_it import MarkdownIt
         "<![CDATA[]]>",  # empty CDATA section
     ],
 )
-def test_shortest_constructs(src: str) -> None:
+def test_shortest_constructs(src):
     """The shortest legal form of each construct is passed through as raw html."""
     assert MarkdownIt("commonmark").renderInline(src) == src
 
 
 @pytest.mark.parametrize("opener", ["<![CDATA[", "<!--", "<?", "<!a", "<a", "</a"])
-def test_unterminated_openers_are_linear(opener: str) -> None:
+def test_unterminated_openers_are_linear(opener):
     """A long run of openers that are never terminated must not be quadratic.
 
     Guarded by the global pytest timeout: before the terminator quick-reject


### PR DESCRIPTION
## Summary

Follow-up to #423, covering the remaining quadratic in the same class that #423 deliberately left out because it is a different code path. With `html=True` (which the `commonmark` and `gfm-like` presets enable), a run of unterminated inline HTML openers in inline context is O(n²):

| input (`"x" + opener × 40 000`) | before | after |
|---|---|---|
| `<[CDATA[` | ~245 s | ~2.3 s |
| `<!--` | ~71 s | ~0.25 s |
| `<?` | ~30 s | ~0.09 s |
| `<!a` | ~3 s | ~0.16 s |

All four now grow ~2.0× per doubling. markdown-it (JavaScript) has the same quadratic shape here (with smaller constants), so unlike #423 this is inherited rather than port-specific; it is still worth fixing because the constants in Python are up to 50× worse.

## Root cause

Every alternative of `HTML_TAG_RE` ends in a specific terminator: `-->` for comments, `?>` for processing instructions, `]]>` for CDATA, `>` for declarations and tags. The lazy sub-patterns (`[\s\S]*?`, `[^>]*`) rescan to the end of the input on every failed attempt, once per opener.

## Fix

- `StateInline.html_terminator_last(term)`: a lazily-populated per-state cache of `src.rfind(term)`, so each distinct terminator costs one scan per inline parse.
- `html_inline` consults it before running the regex and returns `False` when the terminator the opener needs cannot occur at or after the earliest index it could legally start (e.g. `?>` at `pos+2` for `<??>`, `]]>` at `pos+9` for `<[CDATA[]]>`, `-->` at `pos+4` unless the opener is one of the short forms `<!-->` / `<!--->`).

This is a pure quick-reject: it only skips attempts the regex could never match, so **output is unchanged**. The regexes themselves are untouched. The check uses `src` rather than `posMax`, matching how the existing `HTML_TAG_RE.match(state.src, pos)` already behaves inside link labels.

## Verification

- **Output unchanged:** 47,936-case differential (repo fixtures, CommonMark spec, targeted constructs, fuzzed inputs × 7 presets) comparing HTML, `renderInline` and full token streams: 0 differences. A further 4,730-case HTML-focused corpus (all "Raw HTML" spec examples, random strings over `<>!?-[]CDATA/abz \n="'`, random tag concatenations) and 12,000 posMax-restricted variants (inside links, emphasis, blockquotes, tables, images): 0 differences.
- **Bounds proven, not just tested:** an exhaustive check over all strings up to length 6 on the alphabet `<>!?-[Aa/` plus 250,000 random strings, 1,040,507 `<` positions in total, found no position where the quick-reject fired but the regex would have matched.
- **No cost on real documents:** `spec.md` and `README.md` render at 0.99–1.00× (min of 20 reps, interleaved).
- Full suite passes; pre-commit (ruff 0.16.6 / mypy 2.3.1) clean; local docs build adds no warnings.

## Tests (`tests/test_html_inline.py`)

Deterministic rather than timed, so they are immune to coverage and PyPy slowdowns (a first version used the global timeout as a guard and timed out on the PyPy job):

- the shortest legal form of every construct (`<a>`, `</a>`, `<!-->`, `<!--->`, `<!---->`, `<??>`, `<!a>`, `<[CDATA[]]>`) still passes through unchanged;
- for a 1,000-repetition run of each unterminated opener, `HTML_TAG_RE.match` is asserted to be invoked **zero** times (before the fix: once per opener) and the output is the escaped text;
- a run of terminated constructs is asserted to still reach the regex and render as raw HTML.